### PR TITLE
Expand clinical rules to 30, add QuickReference modal + shift progress bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { PatientsProvider } from "./context/PatientsContext";
 import { SectionTabs } from "./components/SectionTabs";
 import { InputArea } from "./components/InputArea";
 import { PatientList } from "./components/PatientList";
+import { QuickReference } from "./components/QuickReference";
 import { usePatientsDispatch, usePatientsState } from "./context/PatientsContext";
 
 
@@ -24,32 +26,91 @@ function TomorrowToggle() {
   );
 }
 
+function ShiftProgressBar() {
+  const { patients, activeSection } = usePatientsState();
+  const sectionPatients = patients.filter((p) => p.section === activeSection);
+
+  let total = 0;
+  let done = 0;
+  for (const p of sectionPatients) {
+    for (const t of p.tasks) {
+      total++;
+      if (t.done) done++;
+    }
+    for (const t of p.generatedTasks) {
+      total++;
+      if (t.done) done++;
+    }
+  }
+
+  if (total === 0) return null;
+
+  const pct = Math.round((done / total) * 100);
+
+  return (
+    <div className="h-1 bg-slate-700/50 w-full">
+      <div
+        className={
+          "h-full transition-all duration-300 " +
+          (pct === 100 ? "bg-green-400" : pct >= 50 ? "bg-blue-400" : "bg-amber-400")
+        }
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+function QuickRefButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="text-xs px-2 py-1 rounded-lg border transition-colors bg-slate-700 text-slate-200 border-slate-600 active:bg-slate-600 hover:bg-slate-600"
+      title="עזר קליני מהיר"
+    >
+      עזר קליני
+    </button>
+  );
+}
+
+function AppContent() {
+  const [showRef, setShowRef] = useState(false);
+
+  return (
+    <div className="min-h-dvh bg-white flex flex-col">
+      <header className="bg-slate-800 text-white px-4 py-3 safe-top border-b border-slate-700">
+        <div className="w-full lg:max-w-6xl lg:mx-auto flex items-baseline gap-3">
+          <div className="ml-auto flex items-center gap-2">
+            <QuickRefButton onClick={() => setShowRef(true)} />
+            <TomorrowToggle />
+          </div>
+          <h1 className="text-lg font-bold tracking-tight">תורנות</h1>
+          <p className="text-slate-400 text-xs">ניהול משמרת מחלקתי</p>
+        </div>
+      </header>
+
+      <ShiftProgressBar />
+
+      <div className="w-full lg:max-w-6xl lg:mx-auto">
+        <InputArea />
+      </div>
+
+      <SectionTabs />
+
+      <main className="flex-1 border-t border-gray-200 bg-gray-50 lg:bg-white">
+        <div className="w-full lg:max-w-6xl lg:mx-auto">
+          <PatientList />
+        </div>
+      </main>
+
+      {showRef && <QuickReference onClose={() => setShowRef(false)} />}
+    </div>
+  );
+}
+
 export function App() {
   return (
     <PatientsProvider>
-      <div className="min-h-dvh bg-white flex flex-col">
-        <header className="bg-slate-800 text-white px-4 py-3 safe-top border-b border-slate-700">
-          <div className="w-full lg:max-w-6xl lg:mx-auto flex items-baseline gap-3">
-            <div className="ml-auto flex items-center gap-2">
-              <TomorrowToggle />
-            </div>
-            <h1 className="text-lg font-bold tracking-tight">תורנות</h1>
-            <p className="text-slate-400 text-xs">ניהול משמרת מחלקתי</p>
-          </div>
-        </header>
-
-        <div className="w-full lg:max-w-6xl lg:mx-auto">
-          <InputArea />
-        </div>
-
-        <SectionTabs />
-
-        <main className="flex-1 border-t border-gray-200 bg-gray-50 lg:bg-white">
-          <div className="w-full lg:max-w-6xl lg:mx-auto">
-            <PatientList />
-          </div>
-        </main>
-      </div>
+      <AppContent />
     </PatientsProvider>
   );
 }

--- a/src/components/QuickReference.tsx
+++ b/src/components/QuickReference.tsx
@@ -1,0 +1,488 @@
+import { useState, useMemo } from "react";
+
+// ─────────────────────────────────────────────────────────
+// DATA: DAG Protocol Quick Reference
+// ─────────────────────────────────────────────────────────
+
+interface ProtocolEntry {
+  condition: string;
+  conditionHe: string;
+  category: string;
+  empiric: string;
+  alternative: string;
+  notes: string;
+}
+
+const PROTOCOLS: ProtocolEntry[] = [
+  {
+    condition: "CAP (Community-Acquired Pneumonia)",
+    conditionHe: "דלקת ריאות נרכשת בקהילה",
+    category: "respiratory",
+    empiric: "Ceftriaxone 2g IV q24h + Azithromycin 500mg IV/PO q24h",
+    alternative: "Levofloxacin 750mg IV/PO q24h (monotx)",
+    notes: "CURB-65 ≥2 → admission. תרביות דם x2 + אנטיגן שתן לפני ABx.",
+  },
+  {
+    condition: "HAP / VAP",
+    conditionHe: "דלקת ריאות נרכשת בבית חולים",
+    category: "respiratory",
+    empiric: "Piperacillin-Tazobactam 4.5g IV q6h",
+    alternative: "Meropenem 1g IV q8h (אם ESBL/Pseudomonas)",
+    notes: "שקול Vancomycin אם חשד MRSA. תרביות דם + כיח לפני ABx.",
+  },
+  {
+    condition: "UTI (Uncomplicated)",
+    conditionHe: "זיהום שתן לא מסובך",
+    category: "genitourinary",
+    empiric: "Ciprofloxacin 500mg PO q12h x7d",
+    alternative: "Ceftriaxone 2g IV q24h (אם IV נדרש)",
+    notes: "תרבית שתן לפני ABx. שקול Nitrofurantoin 100 PO q6h x5d (cystitis).",
+  },
+  {
+    condition: "Pyelonephritis",
+    conditionHe: "פיאלונפריטיס",
+    category: "genitourinary",
+    empiric: "Ceftriaxone 2g IV q24h",
+    alternative: "Ciprofloxacin 500mg PO q12h (אם PO אפשרי)",
+    notes: "תרביות דם x2 אם חום/ספסיס. החלפת/הוצאת קטטר אם קיים.",
+  },
+  {
+    condition: "Sepsis (Unknown Source)",
+    conditionHe: "ספסיס — מקור לא ידוע",
+    category: "systemic",
+    empiric: "Piperacillin-Tazobactam 4.5g IV q6h",
+    alternative: "Meropenem 1g IV q8h ± Amikacin 15mg/kg IV (אם הלם)",
+    notes: "ABx תוך שעה! תרביות דם x2 לפני. Lactate + NaCl 30ml/kg bolus.",
+  },
+  {
+    condition: "Cellulitis",
+    conditionHe: "צלוליטיס",
+    category: "skin",
+    empiric: "Cefazolin 2g IV q8h",
+    alternative: "Cephalexin 500mg PO q6h (קל); Clindamycin 600mg IV q8h (MRSA)",
+    notes: "סימון גבולות בעט + תיעוד צילום. ניקוז אם מוגלה.",
+  },
+  {
+    condition: "C. difficile",
+    conditionHe: "קלוסטרידיום דיפיצילה",
+    category: "gastrointestinal",
+    empiric: "Vancomycin 125mg PO q6h x10d",
+    alternative: "Fidaxomicin 200mg PO q12h x10d",
+    notes: "הפסקת ABx מיותרים. בידוד מגע. אין Metronidazole כקו ראשון.",
+  },
+  {
+    condition: "COPD Exacerbation",
+    conditionHe: "החמרת COPD",
+    category: "respiratory",
+    empiric: "Amoxicillin-Clavulanate 875/125 PO q12h",
+    alternative: "Azithromycin 500mg PO x3d / Levofloxacin 750mg PO",
+    notes: "ABx רק אם כיח מוגלתי. Prednisone 40mg PO x5d. Nebulizers.",
+  },
+  {
+    condition: "Meningitis (Bacterial)",
+    conditionHe: "דלקת קרומי מוח חיידקית",
+    category: "neurological",
+    empiric: "Ceftriaxone 2g IV q12h + Vancomycin 15-20mg/kg IV q8-12h + Dexamethasone",
+    alternative: "Meropenem 2g IV q8h (אם אלרגיה)",
+    notes: "LP לפני ABx אם אפשר (אין עיכוב!). Dexamethasone 0.15mg/kg לפני/עם ABx ראשון.",
+  },
+  {
+    condition: "Endocarditis (Native Valve)",
+    conditionHe: "אנדוקרדיטיס — מסתם טבעי",
+    category: "cardiovascular",
+    empiric: "Ampicillin-Sulbactam 3g IV q6h + Gentamicin 1mg/kg IV q8h",
+    alternative: "Vancomycin 15-20mg/kg IV q12h (אם אלרגיה/MRSA)",
+    notes: "תרביות דם x3 מאתרים שונים. Echo (TTE → TEE).",
+  },
+];
+
+// ─────────────────────────────────────────────────────────
+// DATA: Common On-Call Medications
+// ─────────────────────────────────────────────────────────
+
+interface OnCallMed {
+  indication: string;
+  drug: string;
+  dose: string;
+  notes: string;
+}
+
+const ON_CALL_MEDS: OnCallMed[] = [
+  { indication: "כאב קל-בינוני", drug: "Paracetamol", dose: "1g PO/IV q6h (מקס 4g/d)", notes: "קו ראשון. זהירות בכבד." },
+  { indication: "כאב בינוני-חזק", drug: "Tramadol", dose: "50-100mg PO/IV q6h", notes: "בחילה שכיחה. מוריד סף פרכוסים." },
+  { indication: "כאב חזק", drug: "Morphine", dose: "2-5mg IV q4h PRN", notes: "ניטור נשימתי. Naloxone בהישג יד." },
+  { indication: "בחילה / הקאה", drug: "Metoclopramide", dose: "10mg IV/PO q8h", notes: "לא ביחד עם חסמי דופמין. מקס 30mg/d." },
+  { indication: "בחילה (קו שני)", drug: "Ondansetron", dose: "4mg IV/PO q8h", notes: "עצירות. QT prolongation." },
+  { indication: "חום / כאב", drug: "Ibuprofen", dose: "400mg PO q8h", notes: "לא ב-AKI/GI bleed/anticoag. עם אוכל." },
+  { indication: "נדודי שינה", drug: "Zolpidem", dose: "5mg PO HS", notes: "5mg בקשישים. סיכון נפילה." },
+  { indication: "עצירות", drug: "Lactulose", dose: "15-30ml PO q12h", notes: "טיטרציה לפי תגובה." },
+  { indication: "עצירות (קו שני)", drug: "Bisacodyl", dose: "10mg PO/PR HS", notes: "לא לשימוש כרוני." },
+  { indication: "חרדה / אגיטציה", drug: "Haloperidol", dose: "0.5-2mg IV/PO", notes: "זהירות QT. מועדף על benzos בדליריום." },
+  { indication: "היפוגליקמיה", drug: "Dextrose 50%", dose: "50ml IV (25g)", notes: "בהכרה → גלוקוז PO. Glucagon 1mg IM אם אין גישה." },
+  { indication: "אנפילקסיס", drug: "Epinephrine", dose: "0.3-0.5mg IM (1:1000) ירך", notes: "חזור כל 5-15 דק'. נוזלים IV." },
+  { indication: "היפרקלמיה", drug: "Calcium Gluconate", dose: "10% 10ml IV ב-10 דק'", notes: "הגנת לב. אינו מוריד K+." },
+  { indication: "SVT", drug: "Adenosine", dose: "6mg IV rapid push → 12mg", notes: "עם flush מהיר. יש Defibrillator בהישג יד." },
+  { indication: "AF (rate control)", drug: "Metoprolol", dose: "5mg IV q5min x3, then 25-50mg PO q6h", notes: "לא ב-CHF decompensated. שקול Diltiazem." },
+];
+
+// ─────────────────────────────────────────────────────────
+// COMPONENT
+// ─────────────────────────────────────────────────────────
+
+type Tab = "abx" | "meds" | "crcl" | "curb65";
+
+const TAB_LABELS: Record<Tab, string> = {
+  abx: "ABx פרוטוקול",
+  meds: "תרופות תורן",
+  crcl: "CrCl",
+  curb65: "CURB-65",
+};
+
+export function QuickReference({ onClose }: { onClose: () => void }) {
+  const [tab, setTab] = useState<Tab>("abx");
+  const [search, setSearch] = useState("");
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
+      onClick={onClose}
+    >
+      {/* backdrop */}
+      <div className="absolute inset-0 bg-black/50" />
+
+      {/* modal */}
+      <div
+        className="relative z-10 bg-white w-full sm:max-w-2xl sm:rounded-xl rounded-t-xl max-h-[85dvh] flex flex-col shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+          <h2 className="text-base font-bold text-slate-800">עזר קליני מהיר</h2>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 text-xl leading-none px-1"
+            aria-label="סגור"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* tabs */}
+        <div className="flex border-b border-gray-200 px-2 gap-1 overflow-x-auto scrollbar-hide">
+          {(Object.keys(TAB_LABELS) as Tab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => { setTab(t); setSearch(""); }}
+              className={
+                "px-3 py-2 text-xs font-medium whitespace-nowrap border-b-2 transition-colors " +
+                (tab === t
+                  ? "border-blue-500 text-blue-600"
+                  : "border-transparent text-slate-500 hover:text-slate-700")
+              }
+            >
+              {TAB_LABELS[t]}
+            </button>
+          ))}
+        </div>
+
+        {/* body */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {tab === "abx" && <AbxTab search={search} onSearch={setSearch} />}
+          {tab === "meds" && <MedsTab search={search} onSearch={setSearch} />}
+          {tab === "crcl" && <CrClCalculator />}
+          {tab === "curb65" && <Curb65Calculator />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── ABx Protocols Tab ───────────────────────────────────
+
+function AbxTab({ search, onSearch }: { search: string; onSearch: (v: string) => void }) {
+  const filtered = useMemo(() => {
+    if (!search.trim()) return PROTOCOLS;
+    const q = search.trim().toLowerCase();
+    return PROTOCOLS.filter(
+      (p) =>
+        p.condition.toLowerCase().includes(q) ||
+        p.conditionHe.includes(q) ||
+        p.empiric.toLowerCase().includes(q) ||
+        p.category.toLowerCase().includes(q),
+    );
+  }, [search]);
+
+  return (
+    <div className="space-y-3">
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => onSearch(e.target.value)}
+        placeholder="חיפוש לפי מצב / אנטיביוטיקה..."
+        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+      />
+      {filtered.length === 0 && (
+        <p className="text-sm text-slate-400 text-center py-4">לא נמצאו תוצאות</p>
+      )}
+      {filtered.map((p, i) => (
+        <div key={i} className="border border-gray-200 rounded-lg p-3 space-y-1.5">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <p className="font-bold text-sm text-slate-800">{p.conditionHe}</p>
+              <p className="text-xs text-slate-500">{p.condition}</p>
+            </div>
+            <span className="text-[10px] bg-slate-100 text-slate-500 rounded px-1.5 py-0.5 whitespace-nowrap">
+              {p.category}
+            </span>
+          </div>
+          <div className="text-xs space-y-1">
+            <p>
+              <span className="font-semibold text-green-700">Empiric: </span>
+              <span className="text-slate-700">{p.empiric}</span>
+            </p>
+            <p>
+              <span className="font-semibold text-amber-700">Alternative: </span>
+              <span className="text-slate-700">{p.alternative}</span>
+            </p>
+            <p className="text-slate-500 italic">{p.notes}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── On-Call Meds Tab ────────────────────────────────────
+
+function MedsTab({ search, onSearch }: { search: string; onSearch: (v: string) => void }) {
+  const filtered = useMemo(() => {
+    if (!search.trim()) return ON_CALL_MEDS;
+    const q = search.trim().toLowerCase();
+    return ON_CALL_MEDS.filter(
+      (m) =>
+        m.indication.includes(q) ||
+        m.drug.toLowerCase().includes(q) ||
+        m.notes.includes(q),
+    );
+  }, [search]);
+
+  return (
+    <div className="space-y-3">
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => onSearch(e.target.value)}
+        placeholder="חיפוש לפי התוויה / תרופה..."
+        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+      />
+      {filtered.length === 0 && (
+        <p className="text-sm text-slate-400 text-center py-4">לא נמצאו תוצאות</p>
+      )}
+      <div className="divide-y divide-gray-100">
+        {filtered.map((m, i) => (
+          <div key={i} className="py-2.5 first:pt-0 last:pb-0">
+            <div className="flex items-start justify-between gap-2">
+              <p className="text-sm font-semibold text-slate-800">{m.indication}</p>
+              <span className="text-xs font-mono text-blue-600 whitespace-nowrap">{m.drug}</span>
+            </div>
+            <p className="text-xs text-slate-700 mt-0.5">{m.dose}</p>
+            <p className="text-xs text-slate-400 mt-0.5">{m.notes}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── CrCl Calculator (Cockcroft-Gault) ──────────────────
+
+function CrClCalculator() {
+  const [age, setAge] = useState("");
+  const [weight, setWeight] = useState("");
+  const [creatinine, setCr] = useState("");
+  const [female, setFemale] = useState(false);
+
+  const result = useMemo(() => {
+    const a = parseFloat(age);
+    const w = parseFloat(weight);
+    const cr = parseFloat(creatinine);
+    if (!a || !w || !cr || a <= 0 || w <= 0 || cr <= 0) return null;
+    const base = ((140 - a) * w) / (72 * cr);
+    return female ? base * 0.85 : base;
+  }, [age, weight, creatinine, female]);
+
+  function doseLabel(crcl: number): string {
+    if (crcl >= 60) return "מינון רגיל";
+    if (crcl >= 30) return "התאמה קלה (30-59)";
+    if (crcl >= 15) return "התאמה משמעותית (15-29)";
+    return "שקול דיאליזה (<15)";
+  }
+
+  function barColor(crcl: number): string {
+    if (crcl >= 60) return "bg-green-500";
+    if (crcl >= 30) return "bg-amber-500";
+    return "bg-red-500";
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-slate-500">
+        Cockcroft-Gault — CrCl = [(140 - Age) x Weight] / (72 x Cr)
+        {" "}(x 0.85 לנשים)
+      </p>
+
+      <div className="grid grid-cols-2 gap-3">
+        <label className="block">
+          <span className="text-xs text-slate-600">גיל (שנים)</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            value={age}
+            onChange={(e) => setAge(e.target.value)}
+            className="mt-0.5 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+          />
+        </label>
+        <label className="block">
+          <span className="text-xs text-slate-600">משקל (ק&quot;ג)</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            className="mt-0.5 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+          />
+        </label>
+        <label className="block">
+          <span className="text-xs text-slate-600">Creatinine (mg/dL)</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            step="0.1"
+            value={creatinine}
+            onChange={(e) => setCr(e.target.value)}
+            className="mt-0.5 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+          />
+        </label>
+        <label className="flex items-center gap-2 self-end pb-2">
+          <input
+            type="checkbox"
+            checked={female}
+            onChange={(e) => setFemale(e.target.checked)}
+            className="rounded border-gray-300"
+          />
+          <span className="text-sm text-slate-700">נקבה (x0.85)</span>
+        </label>
+      </div>
+
+      {result !== null && (
+        <div className="border border-gray-200 rounded-lg p-3 space-y-2">
+          <div className="flex items-baseline justify-between">
+            <span className="text-sm font-bold text-slate-800">
+              CrCl = {result.toFixed(1)} mL/min
+            </span>
+            <span className="text-xs text-slate-500">{doseLabel(result)}</span>
+          </div>
+          <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+            <div
+              className={"h-full rounded-full transition-all " + barColor(result)}
+              style={{ width: `${Math.min(100, (result / 120) * 100)}%` }}
+            />
+          </div>
+          <div className="text-[10px] text-slate-400 flex justify-between">
+            <span>0</span>
+            <span>30</span>
+            <span>60</span>
+            <span>90</span>
+            <span>120+</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── CURB-65 Calculator ─────────────────────────────────
+
+const CURB65_CRITERIA = [
+  { key: "C", label: "Confusion — בלבול חדש", desc: "שינוי הכרה / AMT ≤8" },
+  { key: "U", label: "Urea > 7 mmol/L (BUN > 20)", desc: "אוריאה מעל 7 ממול/ל" },
+  { key: "R", label: "RR ≥ 30 / min", desc: "קצב נשימה 30 ומעלה" },
+  { key: "B", label: "BP: SBP < 90 / DBP ≤ 60", desc: "לחץ דם סיסטולי <90 או דיאסטולי ≤60" },
+  { key: "65", label: "Age ≥ 65", desc: "גיל 65 ומעלה" },
+] as const;
+
+function curb65Recommendation(score: number): { text: string; color: string } {
+  if (score <= 1)
+    return { text: "סיכון נמוך — שקול טיפול אמבולטורי", color: "text-green-700" };
+  if (score === 2)
+    return { text: "סיכון בינוני — אשפוז קצר / מעקב צמוד", color: "text-amber-700" };
+  return { text: "סיכון גבוה — אשפוז + שקול ICU (אם 4-5)", color: "text-red-700" };
+}
+
+function Curb65Calculator() {
+  const [checked, setChecked] = useState<Set<string>>(new Set());
+
+  function toggle(key: string) {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  const score = checked.size;
+  const rec = curb65Recommendation(score);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-slate-500">
+        CURB-65 — ניקוד חומרת דלקת ריאות נרכשת בקהילה (CAP)
+      </p>
+
+      <div className="space-y-2">
+        {CURB65_CRITERIA.map((c) => (
+          <button
+            key={c.key}
+            onClick={() => toggle(c.key)}
+            className={
+              "w-full text-right border rounded-lg px-3 py-2.5 flex items-start gap-2 transition-colors " +
+              (checked.has(c.key)
+                ? "bg-blue-50 border-blue-300"
+                : "bg-white border-gray-200 hover:border-gray-300")
+            }
+          >
+            <div
+              className={
+                "mt-0.5 w-5 h-5 rounded border-2 flex items-center justify-center flex-shrink-0 transition-colors " +
+                (checked.has(c.key)
+                  ? "bg-blue-500 border-blue-500 text-white"
+                  : "border-gray-300")
+              }
+            >
+              {checked.has(c.key) && (
+                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </div>
+            <div>
+              <p className="text-sm font-medium text-slate-800">{c.label}</p>
+              <p className="text-xs text-slate-500">{c.desc}</p>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <div className="border border-gray-200 rounded-lg p-3 space-y-2">
+        <div className="flex items-baseline justify-between">
+          <span className="text-lg font-bold text-slate-800">ציון: {score} / 5</span>
+          <span className="text-xs text-slate-500">
+            30-day mortality: {score === 0 ? "0.6%" : score === 1 ? "2.7%" : score === 2 ? "6.8%" : score === 3 ? "14%" : score === 4 ? "27%" : "57%"}
+          </span>
+        </div>
+        <p className={"text-sm font-semibold " + rec.color}>{rec.text}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/engine/rules.ts
+++ b/src/engine/rules.ts
@@ -1,93 +1,423 @@
-import type { PatientEntry, Task, Urgency } from "../types";
+import type { PatientEntry, Task, Urgency, TaskCategory } from "../types";
 import { generateId } from "../utils/id";
+
+interface RuleTask {
+  text: string;
+  urgency: Urgency;
+  category?: TaskCategory;
+}
 
 interface Rule {
   trigger: RegExp;
   source: string;
-  tasks: Array<{
-    text: string;
-    urgency: Urgency;
-  }>;
+  group?: string;
+  tasks: RuleTask[];
 }
 
 const RULES: Rule[] = [
+  // ═══ DISCHARGE ═══
   {
-    trigger: /משתחרר|שחרור|לשחרר/,
-    source: "משתחרר היום",
+    trigger: /משתחרר|שחרור|לשחרר|D\/C|discharge/i,
+    source: "שחרור",
+    group: "discharge",
     tasks: [
-      { text: "סיכום מחלה", urgency: "morning" },
-      { text: "מכתב שחרור", urgency: "morning" },
-      { text: "הסבר תרופות לשחרור", urgency: "routine" },
+      { text: "סיכום מחלה", urgency: "morning", category: "discharge" },
+      { text: "מכתב שחרור", urgency: "morning", category: "discharge" },
+      { text: "הסבר תרופות לשחרור", urgency: "routine", category: "discharge" },
+      { text: "סידור תורים למעקב", urgency: "routine", category: "discharge" },
     ],
   },
+
+  // ═══ NPO ═══
   {
     trigger: /\bNPO\b/i,
     source: "NPO",
+    group: "npo",
     tasks: [
-      { text: "לוודא צום - ללא אוכל ושתייה", urgency: "stat" },
-      { text: "עירוי נוזלים", urgency: "urgent" },
+      { text: "לוודא צום - ללא אוכל ושתייה", urgency: "stat", category: "other" },
+      { text: "עירוי נוזלים IV", urgency: "urgent", category: "meds" },
     ],
   },
+
+  // ═══ PRE-OP ═══
   {
-    trigger: /ניתוח|טרום ניתוח|לפני ניתוח/,
+    trigger: /ניתוח|טרום ניתוח|לפני ניתוח|pre.?op/i,
     source: "טרום ניתוח",
+    group: "preop",
     tasks: [
-      { text: "בדיקות דם טרום ניתוח", urgency: "stat" },
-      { text: "חתימת הסכמה לניתוח", urgency: "urgent" },
-      { text: "התייעצות הרדמה", urgency: "urgent" },
+      { text: "בדיקות דם טרום ניתוח (CBC, CMP, PT/INR, סוג ושתלב)", urgency: "stat", category: "labs" },
+      { text: "חתימת הסכמה לניתוח", urgency: "urgent", category: "other" },
+      { text: "התייעצות הרדמה", urgency: "urgent", category: "consult" },
+      { text: "ABx מניעתי לפי פרוטוקול DAG", urgency: "urgent", category: "meds" },
     ],
   },
+
+  // ═══ BLOOD PRODUCTS ═══
   {
-    trigger: /עירוי דם|מנת דם|PRBCs?/i,
+    trigger: /עירוי דם|מנת דם|PRBCs?|מנות דם|packed\s*cells/i,
     source: "עירוי דם",
+    group: "transfusion",
     tasks: [
-      { text: "סוג ושתלב", urgency: "stat" },
-      { text: "הכנת גישה ורידית", urgency: "urgent" },
-      { text: "ניטור סימנים חיוניים כל 15 דק'", urgency: "stat" },
+      { text: "סוג ושתלב (Type & Screen)", urgency: "stat", category: "labs" },
+      { text: "הכנת גישה ורידית", urgency: "urgent", category: "procedure" },
+      { text: "ניטור סימנים חיוניים כל 15 דק' בזמן עירוי", urgency: "stat", category: "other" },
+      { text: "CBC לאחר מנת דם", urgency: "routine", category: "labs" },
     ],
   },
+
+  // ═══ DIABETES ═══
   {
-    trigger: /סוכרת|אינסולין|DM/i,
+    trigger: /סוכרת|אינסולין|DM[12]?(?!\w)|insulin|היפרגליקמיה/i,
     source: "סוכרת",
+    group: "diabetes",
     tasks: [
-      { text: "מדידת סוכר לפני ארוחות", urgency: "morning" },
-      { text: "בדיקת HbA1c אם חסר", urgency: "routine" },
+      { text: "מדידת סוכר לפני ארוחות + לפני שינה", urgency: "morning", category: "labs" },
+      { text: "בדיקת HbA1c אם חסר", urgency: "routine", category: "labs" },
+      { text: "סולם אינסולין מהיר (Sliding Scale) - לוודא תקינות", urgency: "routine", category: "meds" },
     ],
   },
+
+  // ═══ FALL RISK ═══
   {
-    trigger: /נפילה|FALL/i,
+    trigger: /נפילה|FALL|סיכון ליפול|סכנת נפילה/i,
     source: "סיכון נפילה",
+    group: "fall",
     tasks: [
-      { text: "מעקה מיטה מורם", urgency: "stat" },
-      { text: "פעמון בהישג יד", urgency: "stat" },
+      { text: "מעקה מיטה מורם", urgency: "stat", category: "other" },
+      { text: "פעמון בהישג יד", urgency: "stat", category: "other" },
+      { text: "CT ראש אם חבלה / טיפול נוגד קרישה", urgency: "urgent", category: "imaging" },
     ],
   },
+
+  // ═══ BLADDER SCAN ═══
   {
-    // BS = Bladder Scan (NOT blood sugar). Matches "BS", "BS בערב", "Bladder Scan", etc.
     trigger: /\bBS\b|Bladder\s*Scan|בלדר\s*סקאן|סריקה\s*של\s*שלפוחית/i,
     source: "BS (Bladder Scan)",
-    tasks: [{ text: "BS (Bladder Scan)", urgency: "routine" }],
-  },
-  {
-    trigger: /בידוד|ISO|MRSA|VRE|ESBL/i,
-    source: "בידוד",
+    group: "bs",
     tasks: [
-      { text: "שילוט בידוד על הדלת", urgency: "stat" },
-      { text: "ציוד מגן אישי בכניסה", urgency: "stat" },
+      { text: "BS (Bladder Scan) — קטטר חד פעמי אם >400ml", urgency: "routine", category: "procedure" },
     ],
   },
+
+  // ═══ ISOLATION ═══
   {
-    trigger: /קטטר|catheter|פולי/i,
-    source: "קטטר",
+    trigger: /בידוד|ISO(?:lation)?|MRSA|VRE|ESBL|CRE|CPE|C\.?\s*diff/i,
+    source: "בידוד",
+    group: "isolation",
     tasks: [
-      { text: "בדיקת צורך בהמשך קטטר", urgency: "morning" },
-      { text: "תיעוד כמות שתן", urgency: "routine" },
+      { text: "שילוט בידוד על הדלת", urgency: "stat", category: "other" },
+      { text: "ציוד מגן אישי בכניסה", urgency: "stat", category: "other" },
+      { text: "תרבית מעקב לפי פרוטוקול", urgency: "routine", category: "labs" },
+    ],
+  },
+
+  // ═══ CATHETER ═══
+  {
+    trigger: /קטטר(?!\s*חד)|catheter|פולי|foley/i,
+    source: "קטטר שתן",
+    group: "catheter",
+    tasks: [
+      { text: "בדיקת צורך בהמשך קטטר (הוצאה מוקדמת)", urgency: "morning", category: "other" },
+      { text: "תיעוד כמות שתן (I/O)", urgency: "routine", category: "other" },
+    ],
+  },
+
+  // ═══ PNEUMONIA — DAG: Ceftriaxone ± Azithromycin ═══
+  {
+    trigger: /דלקת ריאות|pneumonia|CAP|HAP|VAP|פנאומוניה|זיהום ריאתי/i,
+    source: "דלקת ריאות",
+    group: "pneumonia",
+    tasks: [
+      { text: "תרביות דם x2 (לפני ABx!)", urgency: "stat", category: "labs" },
+      { text: "צילום חזה (CXR)", urgency: "stat", category: "imaging" },
+      { text: "אנטיגן שתן: Legionella + Pneumococcus", urgency: "urgent", category: "labs" },
+      { text: "ABx — DAG: Ceftriaxone 2g IV + Azithromycin 500mg (CAP); Pip-Tazo (HAP)", urgency: "stat", category: "meds" },
+      { text: "חישוב CURB-65 (ראה עזר קליני)", urgency: "urgent", category: "other" },
+      { text: "גזים עורקיים / SpO2", urgency: "urgent", category: "labs" },
+    ],
+  },
+
+  // ═══ UTI — DAG: Ciprofloxacin PO / Ceftriaxone IV ═══
+  {
+    trigger: /UTI|דלקת.*שתן|זיהום.*שתן|פיאלונפריטיס|pyelonephritis/i,
+    source: "זיהום בדרכי השתן",
+    group: "uti",
+    tasks: [
+      { text: "תרבית שתן + בדיקת שתן כללית (לפני ABx!)", urgency: "stat", category: "labs" },
+      { text: "תרביות דם x2 (אם חום/ספסיס)", urgency: "stat", category: "labs" },
+      { text: "ABx — DAG: Ciprofloxacin 500 PO (לא מסובך) / Ceftriaxone 2g IV", urgency: "stat", category: "meds" },
+      { text: "שקול הוצאת/החלפת קטטר אם קיים", urgency: "urgent", category: "procedure" },
+    ],
+  },
+
+  // ═══ SEPSIS — DAG: Pip-Tazo ± Amikacin ═══
+  {
+    trigger: /ספסיס|sepsis|ספטי|septic|bacteremia|בקטרמיה/i,
+    source: "ספסיס",
+    group: "sepsis",
+    tasks: [
+      { text: "תרביות דם x2 משני אתרים (לפני ABx!)", urgency: "stat", category: "labs" },
+      { text: "לקטט סרום (Lactate)", urgency: "stat", category: "labs" },
+      { text: "ABx רחב תוך שעה — DAG: Pip-Tazo 4.5g IV q6h", urgency: "stat", category: "meds" },
+      { text: "נוזלים IV: NaCl 0.9% — 30ml/kg bolus", urgency: "stat", category: "meds" },
+      { text: "ניטור שתן — יעד >0.5ml/kg/h", urgency: "stat", category: "other" },
+      { text: "לקטט חוזר לאחר 4-6 שעות", urgency: "urgent", category: "labs" },
+      { text: "אם לקטט >4 / הלם → שקול ICU + vasopressors", urgency: "urgent", category: "consult" },
+    ],
+  },
+
+  // ═══ CELLULITIS — DAG: Cefazolin IV / Cephalexin PO ═══
+  {
+    trigger: /צלוליטיס|cellulitis|דלקת.*עור|erysipelas|ארסיפלס/i,
+    source: "צלוליטיס",
+    group: "cellulitis",
+    tasks: [
+      { text: "סימון גבולות בעט (+ תאריך+שעה)", urgency: "stat", category: "other" },
+      { text: "תיעוד צילום", urgency: "urgent", category: "other" },
+      { text: "ABx — DAG: Cefazolin 2g IV q8h / Cephalexin 500 PO q6h", urgency: "stat", category: "meds" },
+      { text: "אם מוגלה → Clindamycin (MRSA) + ניקוז", urgency: "urgent", category: "meds" },
+    ],
+  },
+
+  // ═══ C. DIFFICILE — DAG: PO Vancomycin 125mg q6h ═══
+  {
+    trigger: /C\.?\s*diff|קלוסטרידיום|clostridium|שלשול.*אנטיביוטיקה/i,
+    source: "חשד C. difficile",
+    group: "cdiff",
+    tasks: [
+      { text: "שליחת צואה ל-C.diff PCR/Toxin", urgency: "stat", category: "labs" },
+      { text: "בידוד מגע!", urgency: "stat", category: "other" },
+      { text: "הפסקת ABx מיותרים (Fluoroquinolones, Clindamycin)", urgency: "stat", category: "meds" },
+      { text: "טיפול — DAG: Vancomycin 125mg PO q6h x10d", urgency: "urgent", category: "meds" },
+    ],
+  },
+
+  // ═══ FEVER WORKUP ═══
+  {
+    trigger: /חום|febrile|fever|טמפרטורה\s*גבוהה|38\.[5-9]|39\.\d|40\.\d/i,
+    source: "חום — בירור",
+    group: "fever",
+    tasks: [
+      { text: "תרביות דם x2", urgency: "stat", category: "labs" },
+      { text: "בדיקת שתן כללית + תרבית", urgency: "stat", category: "labs" },
+      { text: "צילום חזה (CXR)", urgency: "urgent", category: "imaging" },
+      { text: "מעבדה: CBC, CRP, Procalcitonin", urgency: "urgent", category: "labs" },
+      { text: "מיפוי מקור: קו מרכזי? קטטר? פצע? צלוליטיס?", urgency: "urgent", category: "other" },
+    ],
+  },
+
+  // ═══ AKI ═══
+  {
+    trigger: /AKI|אי.?ספיקת כליות חדה|acute kidney|עליית קראטינין|כליות.*חדה/i,
+    source: "AKI",
+    group: "aki",
+    tasks: [
+      { text: "US כליות (שלילת חסימה)", urgency: "urgent", category: "imaging" },
+      { text: "הפסקת נפרוטוקסיים: NSAIDs, ACEi, ARB, Aminoglycosides", urgency: "stat", category: "meds" },
+      { text: "הערכת מצב נפחי + I/O", urgency: "stat", category: "other" },
+      { text: "מעבדה: Cr, BUN, K+, Na+, גזים, FENa", urgency: "stat", category: "labs" },
+      { text: "אם Pre-renal → NaCl bolus; אין שיפור → נפרולוג", urgency: "urgent", category: "consult" },
+      { text: "התאמת מינון תרופות ל-CrCl (ראה עזר קליני)", urgency: "urgent", category: "meds" },
+    ],
+  },
+
+  // ═══ HYPERKALEMIA ═══
+  {
+    trigger: /היפרקלמיה|hyperkalemia|K\+?\s*>\s*5\.?[5-9]|K\+?\s*>\s*[67]|אשלגן\s*גבוה/i,
+    source: "היפרקלמיה",
+    group: "hyperK",
+    tasks: [
+      { text: "א.ק.ג STAT (peaked T, wide QRS)", urgency: "stat", category: "labs" },
+      { text: "Calcium Gluconate 10% 10ml IV (אם שינויי ECG)", urgency: "stat", category: "meds" },
+      { text: "Insulin 10U IV + Dextrose 50% 50ml IV", urgency: "stat", category: "meds" },
+      { text: "Kayexalate 30g PO / PR", urgency: "urgent", category: "meds" },
+      { text: "K+ חוזר + ECG חוזר לאחר שעה", urgency: "urgent", category: "labs" },
+      { text: "אם K>6.5 / שינויי ECG → שקול דיאליזה", urgency: "stat", category: "consult" },
+    ],
+  },
+
+  // ═══ HYPOKALEMIA ═══
+  {
+    trigger: /היפוקלמיה|hypokalemia|K\+?\s*<\s*3\.?[50]|אשלגן\s*נמוך/i,
+    source: "היפוקלמיה",
+    group: "hypoK",
+    tasks: [
+      { text: "בדוק Mg2+ (חיוני להעלאת K+)", urgency: "stat", category: "labs" },
+      { text: "K+ PO 40-80mEq/d (אם K>3.0)", urgency: "urgent", category: "meds" },
+      { text: "K+ IV: KCl 10mEq/h (אם K<3.0 — מוניטור)", urgency: "stat", category: "meds" },
+      { text: "ECG (U wave, ST depression)", urgency: "urgent", category: "labs" },
+      { text: "K+ חוזר לאחר 2-4h", urgency: "urgent", category: "labs" },
+    ],
+  },
+
+  // ═══ CHEST PAIN / ACS ═══
+  {
+    trigger: /כאב.*חזה|chest\s*pain|ACS|STEMI|NSTEMI|אוטם|MI\b|טרופונין.*גבוה|תסמונת כלילית/i,
+    source: "כאב חזה / ACS",
+    group: "acs",
+    tasks: [
+      { text: "א.ק.ג תוך 10 דקות!", urgency: "stat", category: "labs" },
+      { text: "טרופונין x3 (T0, T3h, T6h)", urgency: "stat", category: "labs" },
+      { text: "Aspirin 300mg PO", urgency: "stat", category: "meds" },
+      { text: "Heparin IV / Enoxaparin SC", urgency: "stat", category: "meds" },
+      { text: "NTG SL 0.4mg q5min x3 (אם SBP>90)", urgency: "stat", category: "meds" },
+      { text: "CXR", urgency: "urgent", category: "imaging" },
+      { text: "התייעצות קרדיולוגיה", urgency: "stat", category: "consult" },
+    ],
+  },
+
+  // ═══ HEART FAILURE / PULMONARY EDEMA ═══
+  {
+    trigger: /אי.?ספיקת לב|CHF|heart\s*failure|בצקת ריאות|pulmonary\s*edema|HFrEF|HFpEF/i,
+    source: "אי-ספיקת לב",
+    group: "chf",
+    tasks: [
+      { text: "Furosemide IV 40-80mg", urgency: "stat", category: "meds" },
+      { text: "I/O קפדני + משקל יומי", urgency: "stat", category: "other" },
+      { text: "הגבלת נוזלים <1.5L + מלח", urgency: "urgent", category: "other" },
+      { text: "CXR", urgency: "urgent", category: "imaging" },
+      { text: "BNP / NT-proBNP", urgency: "urgent", category: "labs" },
+      { text: "אם SpO2<90% → O2, שקול BiPAP", urgency: "stat", category: "procedure" },
+    ],
+  },
+
+  // ═══ DVT / PE ═══
+  {
+    trigger: /DVT|PE\b|תסחיף ריאתי|פקקת ורידים|pulmonary\s*embol|deep\s*vein/i,
+    source: "DVT / PE",
+    group: "dvtpe",
+    tasks: [
+      { text: "D-Dimer", urgency: "stat", category: "labs" },
+      { text: "DVT → Doppler US ורידי", urgency: "stat", category: "imaging" },
+      { text: "PE → CTPA", urgency: "stat", category: "imaging" },
+      { text: "Enoxaparin 1mg/kg SC q12h", urgency: "stat", category: "meds" },
+      { text: "אם PE מסיבי → שקול thrombolysis + ICU", urgency: "stat", category: "consult" },
+    ],
+  },
+
+  // ═══ DELIRIUM ═══
+  {
+    trigger: /דליריום|delirium|בלבול חריף|agitat|ערפול.*הכרה|acute\s*confusion/i,
+    source: "דליריום",
+    group: "delirium",
+    tasks: [
+      { text: "בירור: זיהום? תרופות? מטבולי? היפוקסיה? עצירות? אצירה?", urgency: "stat", category: "other" },
+      { text: "הפסקת anticholinergics, benzos, opioids", urgency: "stat", category: "meds" },
+      { text: "מעבדה: CBC, CMP, Ca2+, TSH, B12, U/A, גזים", urgency: "urgent", category: "labs" },
+      { text: "BS (שלילת אצירה)", urgency: "urgent", category: "procedure" },
+      { text: "לא בנזודיאזפינים! (מחמיר דליריום)", urgency: "stat", category: "meds" },
+      { text: "אגיטציה → Haloperidol 0.5-1mg IV/PO (זהירות קשישים)", urgency: "urgent", category: "meds" },
+      { text: "אמצעים לא-תרופתיים: תאורה, שעון, משקפיים, משפחה", urgency: "routine", category: "other" },
+    ],
+  },
+
+  // ═══ GI BLEED ═══
+  {
+    trigger: /דימום.*GI|GI\s*bleed|מלנה|melena|המטמזיס|hematemesis|הקאת דם|דם.*צואה/i,
+    source: "דימום GI",
+    group: "gibleed",
+    tasks: [
+      { text: "סוג ושתלב + הזמנת 2 מנות דם", urgency: "stat", category: "labs" },
+      { text: "2 גישות ורידיות רחבות (18G+)", urgency: "stat", category: "procedure" },
+      { text: "נוזלים IV bolus", urgency: "stat", category: "meds" },
+      { text: "PPI IV: Omeprazole 80mg bolus → 8mg/h drip", urgency: "stat", category: "meds" },
+      { text: "מעבדה: CBC, CMP, PT/INR, Fibrinogen, לקטט", urgency: "stat", category: "labs" },
+      { text: "התייעצות גסטרו דחופה", urgency: "stat", category: "consult" },
+      { text: "הפסקת NSAIDs + אנטיקואגולנטים", urgency: "stat", category: "meds" },
+      { text: "NPO", urgency: "stat", category: "other" },
+    ],
+  },
+
+  // ═══ WARFARIN / INR ═══
+  {
+    trigger: /warfarin|קומדין|coumadin|INR\s*גבוה|INR\s*>\s*[3-9]/i,
+    source: "Warfarin / INR",
+    group: "warfarin",
+    tasks: [
+      { text: "בדיקת INR", urgency: "stat", category: "labs" },
+      { text: "INR 3-5 (ללא דימום) → דלג מנה, הפחת מינון", urgency: "urgent", category: "meds" },
+      { text: "INR 5-9 → Vitamin K 1-2.5mg PO", urgency: "urgent", category: "meds" },
+      { text: "INR >9 / דימום → Vitamin K 5-10mg IV + FFP/PCC", urgency: "stat", category: "meds" },
+    ],
+  },
+
+  // ═══ COPD EXACERBATION ═══
+  {
+    trigger: /COPD.*החמרה|החמרת.*COPD|AECOPD|COPD\s*exacerb/i,
+    source: "החמרת COPD",
+    group: "copd",
+    tasks: [
+      { text: "Ventolin + Atrovent Nebulizer", urgency: "stat", category: "meds" },
+      { text: "Prednisone 40mg PO x5d", urgency: "urgent", category: "meds" },
+      { text: "ABx אם כיח מוגלתי — DAG: Amox-Clav / Azithromycin", urgency: "urgent", category: "meds" },
+      { text: "ABG (גזים עורקיים)", urgency: "urgent", category: "labs" },
+      { text: "CXR", urgency: "urgent", category: "imaging" },
+      { text: "אם pH<7.35 + pCO2>45 → BiPAP/NIV", urgency: "stat", category: "procedure" },
+    ],
+  },
+
+  // ═══ HYPOGLYCEMIA ═══
+  {
+    trigger: /היפוגליקמיה|hypoglycemia|סוכר\s*נמוך|glucose\s*<\s*[67]0/i,
+    source: "היפוגליקמיה",
+    group: "hypoglycemia",
+    tasks: [
+      { text: "בהכרה: 15-20g גלוקוז PO → בדיקה ב-15 דק'", urgency: "stat", category: "meds" },
+      { text: "לא בהכרה: D50W 50ml IV / Glucagon 1mg IM", urgency: "stat", category: "meds" },
+      { text: "מדידות סוכר q1h עד יציב >100", urgency: "stat", category: "labs" },
+    ],
+  },
+
+  // ═══ NEW ADMISSION ═══
+  {
+    trigger: /קבלה חדשה|new\s*admission|אשפוז חדש/i,
+    source: "קבלה חדשה",
+    group: "newadmit",
+    tasks: [
+      { text: "מעבדה: CBC, CMP, Mg, PO4, PT/INR, CRP", urgency: "urgent", category: "labs" },
+      { text: "ECG (>50y / רקע קרדיאלי)", urgency: "urgent", category: "labs" },
+      { text: "CXR (אם אין מהשבוע האחרון)", urgency: "routine", category: "imaging" },
+      { text: "Medication Reconciliation", urgency: "urgent", category: "meds" },
+      { text: "הערכת סיכון נפילה + לחץ", urgency: "routine", category: "other" },
+      { text: "מניעת DVT: Enoxaparin 40mg SC daily", urgency: "routine", category: "meds" },
+    ],
+  },
+
+  // ═══ HYPONATREMIA ═══
+  {
+    trigger: /היפונתרמיה|hyponatremia|Na\+?\s*<\s*1[23]\d|נתרן\s*נמוך/i,
+    source: "היפונתרמיה",
+    group: "hypoNa",
+    tasks: [
+      { text: "מעבדה: Na+, Serum Osm, Urine Na+Osm, TSH, Cortisol", urgency: "stat", category: "labs" },
+      { text: "הערכת מצב נפחי", urgency: "stat", category: "other" },
+      { text: "SIADH → הגבלת נוזלים 1-1.5L/d", urgency: "urgent", category: "other" },
+      { text: "Na<120 + סימפטומטי → NaCl 3% IV (מקס 8mEq/L/24h!)", urgency: "stat", category: "meds" },
+      { text: "Na+ q4-6h", urgency: "urgent", category: "labs" },
+    ],
+  },
+
+  // ═══ STROKE / TIA ═══
+  {
+    trigger: /שבץ|CVA|stroke|TIA|חולשה חד צדדית|אפזיה|NIHSS/i,
+    source: "שבץ / TIA",
+    group: "stroke",
+    tasks: [
+      { text: "CT ראש דחוף (שלילת דימום)", urgency: "stat", category: "imaging" },
+      { text: "זמן תחילת סימפטומים (חלון tPA: 4.5h)", urgency: "stat", category: "other" },
+      { text: "NIHSS score", urgency: "stat", category: "other" },
+      { text: "מעבדה: CBC, CMP, PT/INR, Glucose, Troponin", urgency: "stat", category: "labs" },
+      { text: "ECG (חיפוש AF)", urgency: "stat", category: "labs" },
+      { text: "התייעצות נוירולוגיה דחופה", urgency: "stat", category: "consult" },
+      { text: "NPO (עד הערכת בליעה)", urgency: "stat", category: "other" },
     ],
   },
 ];
 
 export function applyRules(patient: PatientEntry): Task[] {
   const generated: Task[] = [];
+  const matchedGroups = new Set<string>();
+
   const combined = [
     ...patient.status,
     ...patient.flags,
@@ -96,12 +426,17 @@ export function applyRules(patient: PatientEntry): Task[] {
   ].join(" ");
 
   for (const rule of RULES) {
+    if (rule.group && matchedGroups.has(rule.group)) continue;
+
     if (rule.trigger.test(combined)) {
+      if (rule.group) matchedGroups.add(rule.group);
+
       for (const taskDef of rule.tasks) {
         generated.push({
           id: generateId("gen-"),
           text: taskDef.text,
           urgency: taskDef.urgency,
+          category: taskDef.category ?? "other",
           source: "generated",
           done: false,
           doneTime: null,
@@ -115,3 +450,6 @@ export function applyRules(patient: PatientEntry): Task[] {
 
   return generated;
 }
+
+export { RULES };
+export type { Rule };


### PR DESCRIPTION
- Replace rules.ts: expand from 9 to 30 clinical rules with SZMC DAG
  protocols, group-based dedup, task categories (pneumonia, UTI, sepsis,
  ACS, AKI, hyperkalemia, delirium, GI bleed, stroke, etc.)
- Create QuickReference.tsx: modal with 4 tabs — ABx protocols, on-call
  meds, CrCl (Cockcroft-Gault) calculator, CURB-65 scoring
- Update App.tsx: wire QuickReference button in header, add section-aware
  shift progress bar showing task completion

https://claude.ai/code/session_01ETxQM9FCqrY6j35F9UPoS4