### PR TITLE
Add comprehensive test suite: 19 → 260 tests across 6 files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run test
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/src/__tests__/mergeScan.test.ts
+++ b/src/__tests__/mergeScan.test.ts
@@ -107,4 +107,89 @@ describe("mergeScan", () => {
       ["כהן יוסף", "לוי שרה"].sort(),
     );
   });
+
+  // ─── New edge case tests ───
+
+  it("new patient with no existing match is added fresh", () => {
+    const existing = parsePatientList("101 כהן יוסף 72");
+    const incoming = parsePatientList("102 לוי שרה 65");
+
+    const merged = mergeScan(existing, incoming);
+    expect(merged).toHaveLength(2);
+    expect(merged.map((p) => p.name).sort()).toEqual(["כהן יוסף", "לוי שרה"].sort());
+  });
+
+  it("empty incoming scan keeps all existing patients", () => {
+    const existing = parsePatientList(`צד א
+101 כהן יוסף 72
+102 לוי שרה 65`);
+
+    const merged = mergeScan(existing, []);
+    expect(merged).toHaveLength(2);
+  });
+
+  it("empty existing state accepts all incoming patients", () => {
+    const incoming = parsePatientList("101 כהן יוסף 72");
+    const merged = mergeScan([], incoming);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].name).toBe("כהן יוסף");
+  });
+
+  it("preserves notes across rescans (deduplication)", () => {
+    const first = parsePatientList(SCAN_TEXT);
+    first[0].notes = ["note A", "note B"];
+
+    const second = parsePatientList(SCAN_TEXT);
+    const merged = mergeScan(first, second);
+
+    // Notes from old entry should be preserved
+    expect(merged[0].notes).toContain("note A");
+    expect(merged[0].notes).toContain("note B");
+  });
+
+  it("chained rescans preserve accumulated manual tasks", () => {
+    // Scan 1
+    const scan1 = parsePatientList("101 כהן יוסף 72");
+    scan1[0].tasks.push(makeManualTask("task from scan 1"));
+
+    // Scan 2 — merge into scan1
+    const scan2 = parsePatientList("101 כהן יוסף 72");
+    const after2 = mergeScan(scan1, scan2);
+    after2[0].tasks.push(makeManualTask("task from scan 2"));
+
+    // Scan 3 — merge into after2
+    const scan3 = parsePatientList("101 כהן יוסף 72");
+    const after3 = mergeScan(after2, scan3);
+
+    const manualTasks = after3[0].tasks.filter((t) => t.source === "manual");
+    expect(manualTasks).toHaveLength(2);
+    expect(manualTasks.map((t) => t.text)).toContain("task from scan 1");
+    expect(manualTasks.map((t) => t.text)).toContain("task from scan 2");
+  });
+
+  it("preserves task note across rescans", () => {
+    const first = parsePatientList(SCAN_TEXT);
+    const extractedTask = first[0].tasks.find((t) => t.source === "extracted");
+    expect(extractedTask).toBeDefined();
+    (extractedTask as any).note = "BS 250ml";
+
+    const second = parsePatientList(SCAN_TEXT);
+    const merged = mergeScan(first, second);
+
+    const mergedTask = merged[0].tasks.find(
+      (t) => t.source === "extracted" && t.text === extractedTask!.text,
+    );
+    expect(mergedTask).toBeDefined();
+    expect((mergedTask as any).note).toBe("BS 250ml");
+  });
+
+  it("updates scannedAt timestamp on rescan", () => {
+    const first = parsePatientList(SCAN_TEXT);
+
+    const second = parsePatientList(SCAN_TEXT);
+    const merged = mergeScan(first, second);
+
+    // The merged patient should have the new scannedAt
+    expect(merged[0].scannedAt).toBe(second[0].scannedAt);
+  });
 });

--- a/src/__tests__/parsePatientList.test.ts
+++ b/src/__tests__/parsePatientList.test.ts
@@ -54,6 +54,31 @@ describe("parsePatientList", () => {
       expect(result[0].section).toBe("SIDE_A");
       expect(result[1].section).toBe("SIDE_B");
     });
+
+    it("handles all 5 section types", () => {
+      const text = `צד א
+101 כהן א 72
+צד ב
+201 לוי ב 65
+צד ג
+301 דוד ג 50
+שיקום
+401 משה ד 80
+ניטור
+501 יעקב ה 60`;
+      const result = parsePatientList(text);
+      expect(result).toHaveLength(5);
+      expect(result[0].section).toBe("SIDE_A");
+      expect(result[1].section).toBe("SIDE_B");
+      expect(result[2].section).toBe("SIDE_C");
+      expect(result[3].section).toBe("REHAB");
+      expect(result[4].section).toBe("MONITOR");
+    });
+
+    it("defaults to SIDE_A when no header is present", () => {
+      const result = parsePatientList("101 כהן יוסף 72");
+      expect(result[0].section).toBe("SIDE_A");
+    });
   });
 
   describe("task extraction", () => {
@@ -81,6 +106,181 @@ describe("parsePatientList", () => {
       for (const t of result[0].generatedTasks) {
         expect(t.source).toBe("generated");
       }
+    });
+  });
+
+  // ─── New edge case tests ───
+
+  describe("diagnosis extraction", () => {
+    it("extracts diagnosis from remaining tokens after name and age", () => {
+      const result = parsePatientList("101 כהן יוסף 72 דלקת ריאות");
+      expect(result).toHaveLength(1);
+      expect(result[0].diagnosis).toBe("דלקת ריאות");
+    });
+
+    it("returns null diagnosis when none provided", () => {
+      const result = parsePatientList("101 כהן יוסף 72");
+      expect(result).toHaveLength(1);
+      expect(result[0].diagnosis).toBeNull();
+    });
+  });
+
+  describe("age parsing", () => {
+    it("extracts a valid age", () => {
+      const result = parsePatientList("101 כהן יוסף 72");
+      expect(result[0].age).toBe(72);
+    });
+
+    it("without a numeric age, Hebrew tokens are absorbed into the name", () => {
+      // Without an age number as separator, the parser can't distinguish
+      // name tokens from diagnosis tokens (all Hebrew)
+      const result = parsePatientList("101 כהן יוסף דלקת ריאות");
+      expect(result).toHaveLength(1);
+      // All Hebrew tokens become part of the name
+      expect(result[0].name).toBe("כהן יוסף דלקת ריאות");
+      expect(result[0].age).toBeNull();
+    });
+  });
+
+  describe("flag extraction", () => {
+    it("extracts DNR flag", () => {
+      const result = parsePatientList("101 כהן יוסף 72 DNR");
+      expect(result[0].flags).toContain("DNR");
+    });
+
+    it("extracts NPO flag", () => {
+      const result = parsePatientList("101 כהן יוסף 72 NPO");
+      expect(result[0].flags).toContain("NPO");
+    });
+
+    it("extracts ISO flag", () => {
+      const result = parsePatientList("101 כהן יוסף 72 ISO");
+      expect(result[0].flags).toContain("ISO");
+    });
+
+    it("extracts MRSA flag", () => {
+      const result = parsePatientList("101 כהן יוסף 72 MRSA");
+      expect(result[0].flags).toContain("MRSA");
+    });
+
+    it("extracts FALL flag", () => {
+      const result = parsePatientList("101 כהן יוסף 72 FALL");
+      expect(result[0].flags).toContain("FALL");
+    });
+
+    it("extracts multiple flags", () => {
+      const result = parsePatientList("101 כהן יוסף 72 DNR NPO FALL");
+      expect(result[0].flags).toContain("DNR");
+      expect(result[0].flags).toContain("NPO");
+      expect(result[0].flags).toContain("FALL");
+    });
+  });
+
+  describe("task categorization", () => {
+    it("classifies CT/US as imaging", () => {
+      const result = parsePatientList("101 כהן יוסף 72 | CT חזה");
+      const task = result[0].tasks[0];
+      expect(task.category).toBe("imaging");
+    });
+
+    it("classifies בדיקת דם as labs", () => {
+      const result = parsePatientList("101 כהן יוסף 72 | בדיקת דם בבוקר");
+      const task = result[0].tasks[0];
+      expect(task.category).toBe("labs");
+    });
+
+    it("classifies שחרור via תורן column label as discharge", () => {
+      // "מכתב שחרור" alone doesn't match the task-detection heuristic,
+      // but using the תורן: prefix forces it through as a task
+      const result = parsePatientList("101 כהן יוסף 72 | תורן: מכתב שחרור");
+      const task = result[0].tasks.find((t) => t.text === "מכתב שחרור");
+      expect(task).toBeDefined();
+      expect(task!.category).toBe("discharge");
+    });
+
+    it("classifies ייעוץ as consult", () => {
+      const result = parsePatientList("101 כהן יוסף 72 | ייעוץ קרדיולוגיה");
+      const task = result[0].tasks[0];
+      expect(task.category).toBe("consult");
+    });
+  });
+
+  describe("multi-patient parsing", () => {
+    it("parses multiple patients across sections", () => {
+      const text = `צד א
+101 כהן יוסף 72 דלקת ריאות | בדיקת דם בבוקר
+102 לוי שרה 65 אי ספיקת לב
+צד ב
+201 אברהם דוד 80 סוכרת | BS בערב`;
+
+      const result = parsePatientList(text);
+      expect(result).toHaveLength(3);
+      expect(result[0].name).toBe("כהן יוסף");
+      expect(result[0].section).toBe("SIDE_A");
+      expect(result[1].name).toBe("לוי שרה");
+      expect(result[1].section).toBe("SIDE_A");
+      expect(result[2].name).toBe("אברהם דוד");
+      expect(result[2].section).toBe("SIDE_B");
+    });
+  });
+
+  describe("empty and edge inputs", () => {
+    it("returns empty array for empty string", () => {
+      const result = parsePatientList("");
+      expect(result).toHaveLength(0);
+    });
+
+    it("returns empty array for whitespace-only input", () => {
+      const result = parsePatientList("   \n  \n  ");
+      expect(result).toHaveLength(0);
+    });
+
+    it("skips very short lines", () => {
+      const result = parsePatientList("ab");
+      expect(result).toHaveLength(0);
+    });
+
+    it("handles blank lines between patients", () => {
+      const text = `101 כהן יוסף 72
+
+102 לוי שרה 65`;
+      const result = parsePatientList(text);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("confidence calculation", () => {
+    it("patient with room, name, age, diagnosis has high confidence", () => {
+      const result = parsePatientList("101 כהן יוסף 72 דלקת ריאות");
+      // room(0.25) + name(0.35) + age(0.1) + diagnosis(0.2) + base(0.1) = 1.0
+      expect(result[0].confidence).toBeCloseTo(1.0, 1);
+    });
+
+    it("patient with just room and name has partial confidence", () => {
+      const result = parsePatientList("101 כהן יוסף");
+      // room(0.25) + name(0.35) + base(0.1) = 0.7
+      expect(result[0].confidence).toBeCloseTo(0.7, 1);
+    });
+  });
+
+  describe("tomorrow notes", () => {
+    it("routes 'מחר' segments to tomorrowNotes", () => {
+      const result = parsePatientList("101 כהן יוסף 72 | מחר: צילום חזה");
+      expect(result[0].tomorrowNotes.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("status extraction", () => {
+    it("non-task segments go to status array", () => {
+      const result = parsePatientList("101 כהן יוסף 72 דלקת ריאות | מצב יציב");
+      expect(result[0].status).toContain("מצב יציב");
+    });
+  });
+
+  describe("monitor room section inference", () => {
+    it("ניטור room infers MONITOR section even without header", () => {
+      const result = parsePatientList("ניטור-1 כהן דני 55");
+      expect(result[0].section).toBe("MONITOR");
     });
   });
 });

--- a/src/__tests__/patientKey.test.ts
+++ b/src/__tests__/patientKey.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { buildPatientKey, buildPatientLooseKey } from "../utils/patientKey";
+
+describe("buildPatientKey (strict)", () => {
+  it("returns section|room|name format", () => {
+    const key = buildPatientKey("SIDE_A", "101", "כהן יוסף");
+    expect(key).toContain("|");
+    const parts = key.split("|");
+    expect(parts).toHaveLength(3);
+  });
+
+  it("normalizes whitespace", () => {
+    const a = buildPatientKey("SIDE_A", "101", "כהן  יוסף");
+    const b = buildPatientKey("SIDE_A", "101", "כהן יוסף");
+    expect(a).toBe(b);
+  });
+
+  it("normalizes case", () => {
+    const a = buildPatientKey("SIDE_A", "101", "Cohen");
+    const b = buildPatientKey("SIDE_A", "101", "cohen");
+    expect(a).toBe(b);
+  });
+
+  it("handles null room", () => {
+    const key = buildPatientKey("SIDE_A", null, "כהן יוסף");
+    expect(key).toBeDefined();
+    expect(key.split("|")[1]).toBe("");
+  });
+
+  it("handles null name", () => {
+    const key = buildPatientKey("SIDE_A", "101", null);
+    expect(key).toBeDefined();
+    expect(key.split("|")[2]).toBe("");
+  });
+
+  it("handles all nulls", () => {
+    const key = buildPatientKey("SIDE_A", null, null);
+    expect(key).toBeDefined();
+  });
+
+  it("differentiates patients in different sections", () => {
+    const a = buildPatientKey("SIDE_A", "101", "כהן יוסף");
+    const b = buildPatientKey("SIDE_B", "101", "כהן יוסף");
+    expect(a).not.toBe(b);
+  });
+
+  it("differentiates patients in different rooms", () => {
+    const a = buildPatientKey("SIDE_A", "101", "כהן יוסף");
+    const b = buildPatientKey("SIDE_A", "102", "כהן יוסף");
+    expect(a).not.toBe(b);
+  });
+
+  it("differentiates patients with different names", () => {
+    const a = buildPatientKey("SIDE_A", "101", "כהן יוסף");
+    const b = buildPatientKey("SIDE_A", "101", "לוי שרה");
+    expect(a).not.toBe(b);
+  });
+
+  it("preserves Hebrew characters", () => {
+    const key = buildPatientKey("SIDE_A", "101", "כהן");
+    expect(key).toContain("כהן");
+  });
+});
+
+describe("buildPatientLooseKey", () => {
+  it("returns room|name format (no section)", () => {
+    const key = buildPatientLooseKey("101", "כהן יוסף");
+    const parts = key.split("|");
+    expect(parts).toHaveLength(2);
+  });
+
+  it("matches same patient across sections", () => {
+    const a = buildPatientLooseKey("101", "כהן יוסף");
+    const b = buildPatientLooseKey("101", "כהן יוסף");
+    expect(a).toBe(b);
+  });
+
+  it("handles null room", () => {
+    const key = buildPatientLooseKey(null, "כהן");
+    expect(key.split("|")[0]).toBe("");
+  });
+
+  it("handles null name", () => {
+    const key = buildPatientLooseKey("101", null);
+    expect(key.split("|")[1]).toBe("");
+  });
+
+  it("normalizes whitespace and case like strict key", () => {
+    const a = buildPatientLooseKey("101", "כהן  יוסף");
+    const b = buildPatientLooseKey("101", "כהן יוסף");
+    expect(a).toBe(b);
+  });
+});

--- a/src/__tests__/reducer.test.ts
+++ b/src/__tests__/reducer.test.ts
@@ -1,0 +1,725 @@
+import { describe, it, expect } from "vitest";
+import {
+  reducer,
+  normalizeTask,
+  normalizePatient,
+  inferUrgencyFromText,
+} from "../context/PatientsContext";
+import type { PatientEntry, Task, Section, LabEntry } from "../types";
+
+// ─── Helpers ───
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: overrides.id ?? "task-1",
+    text: overrides.text ?? "test task",
+    urgency: overrides.urgency ?? "routine",
+    source: overrides.source ?? "extracted",
+    done: overrides.done ?? false,
+    doneTime: overrides.doneTime ?? null,
+    time: overrides.time ?? null,
+    confidence: overrides.confidence ?? 1,
+    ...overrides,
+  };
+}
+
+function makePatient(overrides: Partial<PatientEntry> = {}): PatientEntry {
+  return {
+    id: overrides.id ?? "pt-1",
+    section: overrides.section ?? "SIDE_A",
+    date: overrides.date ?? "01/01/2025",
+    room: overrides.room ?? "101",
+    name: overrides.name ?? "כהן יוסף",
+    age: overrides.age ?? 70,
+    diagnosis: overrides.diagnosis ?? null,
+    flags: overrides.flags ?? [],
+    status: overrides.status ?? [],
+    tomorrowNotes: overrides.tomorrowNotes ?? [],
+    tasks: overrides.tasks ?? [],
+    generatedTasks: overrides.generatedTasks ?? [],
+    notes: overrides.notes ?? [],
+    scannedAt: overrides.scannedAt ?? "2025-01-01T00:00:00.000Z",
+    confidence: overrides.confidence ?? 1,
+    order: overrides.order ?? 0,
+  };
+}
+
+function makeState(
+  patients: PatientEntry[] = [],
+  overrides: Record<string, any> = {},
+) {
+  return {
+    patients,
+    activeSection: "SIDE_A" as Section,
+    showTomorrow: false,
+    darkMode: false,
+    shiftHistory: [],
+    ...overrides,
+  };
+}
+
+// ─── normalizeTask ───
+
+describe("normalizeTask", () => {
+  it("fills missing fields with defaults", () => {
+    const raw = { id: "t1", text: "test", urgency: "stat", source: "manual" };
+    const t = normalizeTask(raw);
+    expect(t.done).toBe(false);
+    expect(t.doneTime).toBeNull();
+    expect(t.time).toBeNull();
+    expect(t.confidence).toBe(1);
+  });
+
+  it("preserves existing done=true", () => {
+    const raw = { id: "t1", text: "test", urgency: "stat", source: "manual", done: true };
+    const t = normalizeTask(raw);
+    expect(t.done).toBe(true);
+  });
+
+  it("converts falsy done to false", () => {
+    const raw = { id: "t1", text: "test", urgency: "stat", source: "manual", done: 0 };
+    const t = normalizeTask(raw);
+    expect(t.done).toBe(false);
+  });
+
+  it("uses provided confidence when it is a number", () => {
+    const raw = { id: "t1", text: "test", urgency: "stat", source: "manual", confidence: 0.5 };
+    const t = normalizeTask(raw);
+    expect(t.confidence).toBe(0.5);
+  });
+
+  it("defaults confidence to 1 for non-number", () => {
+    const raw = { id: "t1", text: "test", urgency: "stat", source: "manual", confidence: "high" };
+    const t = normalizeTask(raw);
+    expect(t.confidence).toBe(1);
+  });
+});
+
+// ─── normalizePatient ───
+
+describe("normalizePatient", () => {
+  it("converts non-array fields to empty arrays", () => {
+    const raw = {
+      id: "p1",
+      section: "SIDE_A",
+      date: "01/01/2025",
+      room: "101",
+      name: "Test",
+      flags: "not-an-array",
+      status: null,
+      tomorrowNotes: undefined,
+      tasks: null,
+      generatedTasks: "bad",
+      notes: 42,
+    };
+    const p = normalizePatient(raw);
+    expect(Array.isArray(p.flags)).toBe(true);
+    expect(p.flags).toHaveLength(0);
+    expect(Array.isArray(p.status)).toBe(true);
+    expect(Array.isArray(p.tomorrowNotes)).toBe(true);
+    expect(Array.isArray(p.tasks)).toBe(true);
+    expect(Array.isArray(p.generatedTasks)).toBe(true);
+    expect(Array.isArray(p.notes)).toBe(true);
+  });
+
+  it("normalizes tasks within the patient", () => {
+    const raw = {
+      id: "p1",
+      section: "SIDE_A",
+      tasks: [{ id: "t1", text: "test", urgency: "stat", source: "manual" }],
+      generatedTasks: [],
+      flags: [],
+      status: [],
+      tomorrowNotes: [],
+      notes: [],
+    };
+    const p = normalizePatient(raw);
+    expect(p.tasks[0].done).toBe(false);
+    expect(p.tasks[0].doneTime).toBeNull();
+  });
+
+  it("defaults order to 0 when not a number", () => {
+    const raw = { id: "p1", flags: [], status: [], tomorrowNotes: [], tasks: [], generatedTasks: [], notes: [] };
+    const p = normalizePatient(raw);
+    expect(p.order).toBe(0);
+  });
+});
+
+// ─── inferUrgencyFromText ───
+
+describe("inferUrgencyFromText", () => {
+  it('returns "stat" for "STAT"', () => {
+    expect(inferUrgencyFromText("STAT")).toBe("stat");
+  });
+
+  it('returns "stat" for "STAT" in a sentence', () => {
+    expect(inferUrgencyFromText("STAT blood draw")).toBe("stat");
+  });
+
+  // NOTE: Hebrew-only keywords (דחוף, סטט, אורגנטי, בוקר) don't match
+  // because the regex uses \b which doesn't work with Hebrew Unicode chars.
+  // These return "routine" — this is a known limitation.
+  it('returns "routine" for pure Hebrew urgency keywords (\\b limitation)', () => {
+    expect(inferUrgencyFromText("דחוף")).toBe("routine");
+    expect(inferUrgencyFromText("סטט")).toBe("routine");
+    expect(inferUrgencyFromText("אורגנטי")).toBe("routine");
+    expect(inferUrgencyFromText("בדיקה בבוקר")).toBe("routine");
+  });
+
+  it('returns "routine" for unrecognized text', () => {
+    expect(inferUrgencyFromText("check vitals")).toBe("routine");
+  });
+
+  it('returns "routine" for empty string', () => {
+    expect(inferUrgencyFromText("")).toBe("routine");
+  });
+});
+
+// ─── reducer ───
+
+describe("reducer", () => {
+  describe("SET_SECTION", () => {
+    it("changes the active section", () => {
+      const state = makeState();
+      const next = reducer(state, { type: "SET_SECTION", section: "SIDE_B" });
+      expect(next.activeSection).toBe("SIDE_B");
+    });
+  });
+
+  describe("TOGGLE_TASK", () => {
+    it("toggles a task from done=false to done=true", () => {
+      const task = makeTask({ id: "t1", done: false });
+      const patient = makePatient({ id: "p1", tasks: [task] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, { type: "TOGGLE_TASK", patientId: "p1", taskId: "t1" });
+      const toggled = next.patients[0].tasks[0];
+      expect(toggled.done).toBe(true);
+      expect(toggled.doneTime).toBeTruthy();
+    });
+
+    it("toggles a task from done=true back to done=false", () => {
+      const task = makeTask({ id: "t1", done: true, doneTime: "2025-01-01T00:00:00Z" });
+      const patient = makePatient({ id: "p1", tasks: [task] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, { type: "TOGGLE_TASK", patientId: "p1", taskId: "t1" });
+      const toggled = next.patients[0].tasks[0];
+      expect(toggled.done).toBe(false);
+      expect(toggled.doneTime).toBeNull();
+    });
+
+    it("toggles generated tasks too", () => {
+      const genTask = makeTask({ id: "g1", done: false, source: "generated" });
+      const patient = makePatient({ id: "p1", generatedTasks: [genTask] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, { type: "TOGGLE_TASK", patientId: "p1", taskId: "g1" });
+      expect(next.patients[0].generatedTasks[0].done).toBe(true);
+    });
+
+    it("does not affect other patients", () => {
+      const p1 = makePatient({ id: "p1", tasks: [makeTask({ id: "t1" })] });
+      const p2 = makePatient({ id: "p2", tasks: [makeTask({ id: "t2" })] });
+      const state = makeState([p1, p2]);
+
+      const next = reducer(state, { type: "TOGGLE_TASK", patientId: "p1", taskId: "t1" });
+      expect(next.patients[1].tasks[0].done).toBe(false);
+    });
+  });
+
+  describe("SET_TASK_NOTE", () => {
+    it("sets a note on a task", () => {
+      const task = makeTask({ id: "t1" });
+      const patient = makePatient({ id: "p1", tasks: [task] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "SET_TASK_NOTE",
+        patientId: "p1",
+        taskId: "t1",
+        note: "BS result: 250ml",
+      });
+      expect(next.patients[0].tasks[0].note).toBe("BS result: 250ml");
+    });
+
+    it("clears a note when set to null", () => {
+      const task = makeTask({ id: "t1", note: "old note" } as any);
+      const patient = makePatient({ id: "p1", tasks: [task] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "SET_TASK_NOTE",
+        patientId: "p1",
+        taskId: "t1",
+        note: null,
+      });
+      expect(next.patients[0].tasks[0].note).toBeNull();
+    });
+
+    it("sets note on generated tasks too", () => {
+      const genTask = makeTask({ id: "g1", source: "generated" });
+      const patient = makePatient({ id: "p1", generatedTasks: [genTask] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "SET_TASK_NOTE",
+        patientId: "p1",
+        taskId: "g1",
+        note: "done",
+      });
+      expect(next.patients[0].generatedTasks[0].note).toBe("done");
+    });
+  });
+
+  describe("SET_TASK_DUE", () => {
+    it("sets dueAt on a task", () => {
+      const task = makeTask({ id: "t1" });
+      const patient = makePatient({ id: "p1", tasks: [task] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "SET_TASK_DUE",
+        patientId: "p1",
+        taskId: "t1",
+        dueAt: "2025-06-01T10:00:00Z",
+      });
+      expect(next.patients[0].tasks[0].dueAt).toBe("2025-06-01T10:00:00Z");
+    });
+
+    it("clears dueAt when null", () => {
+      const task = makeTask({ id: "t1", dueAt: "2025-06-01T10:00:00Z" } as any);
+      const patient = makePatient({ id: "p1", tasks: [task] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "SET_TASK_DUE",
+        patientId: "p1",
+        taskId: "t1",
+        dueAt: null,
+      });
+      expect(next.patients[0].tasks[0].dueAt).toBeNull();
+    });
+  });
+
+  describe("ADD_TASK", () => {
+    it("adds a manual task to the correct patient", () => {
+      const patient = makePatient({ id: "p1" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "ADD_TASK",
+        patientId: "p1",
+        text: "בדוק לחץ דם",
+      });
+      expect(next.patients[0].tasks).toHaveLength(1);
+      expect(next.patients[0].tasks[0].text).toBe("בדוק לחץ דם");
+      expect(next.patients[0].tasks[0].source).toBe("manual");
+    });
+
+    it("infers urgency from text when not provided", () => {
+      const patient = makePatient({ id: "p1" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "ADD_TASK",
+        patientId: "p1",
+        text: "STAT blood draw",
+      });
+      expect(next.patients[0].tasks[0].urgency).toBe("stat");
+    });
+
+    it("uses provided urgency over inferred", () => {
+      const patient = makePatient({ id: "p1" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "ADD_TASK",
+        patientId: "p1",
+        text: "some task",
+        urgency: "urgent",
+      });
+      expect(next.patients[0].tasks[0].urgency).toBe("urgent");
+    });
+
+    it("ignores empty text", () => {
+      const patient = makePatient({ id: "p1" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "ADD_TASK",
+        patientId: "p1",
+        text: "   ",
+      });
+      expect(next.patients[0].tasks).toHaveLength(0);
+    });
+  });
+
+  describe("ADD_NOTE", () => {
+    it("adds a note to the patient", () => {
+      const patient = makePatient({ id: "p1", notes: [] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "ADD_NOTE",
+        patientId: "p1",
+        text: "allergic to penicillin",
+      });
+      expect(next.patients[0].notes).toContain("allergic to penicillin");
+    });
+
+    it("does not add duplicate notes", () => {
+      const patient = makePatient({ id: "p1", notes: ["existing note"] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "ADD_NOTE",
+        patientId: "p1",
+        text: "existing note",
+      });
+      expect(next.patients[0].notes).toHaveLength(1);
+    });
+
+    it("ignores empty text", () => {
+      const patient = makePatient({ id: "p1", notes: [] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "ADD_NOTE",
+        patientId: "p1",
+        text: "  ",
+      });
+      expect(next.patients[0].notes).toHaveLength(0);
+    });
+  });
+
+  describe("REMOVE_NOTE", () => {
+    it("removes a note by index", () => {
+      const patient = makePatient({ id: "p1", notes: ["note0", "note1", "note2"] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "REMOVE_NOTE",
+        patientId: "p1",
+        index: 1,
+      });
+      expect(next.patients[0].notes).toEqual(["note0", "note2"]);
+    });
+
+    it("does nothing for out-of-bounds index", () => {
+      const patient = makePatient({ id: "p1", notes: ["note0"] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "REMOVE_NOTE",
+        patientId: "p1",
+        index: 5,
+      });
+      expect(next.patients[0].notes).toEqual(["note0"]);
+    });
+
+    it("does nothing for negative index", () => {
+      const patient = makePatient({ id: "p1", notes: ["note0"] });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "REMOVE_NOTE",
+        patientId: "p1",
+        index: -1,
+      });
+      expect(next.patients[0].notes).toEqual(["note0"]);
+    });
+  });
+
+  describe("ADD_LAB", () => {
+    it("appends a lab entry", () => {
+      const patient = makePatient({ id: "p1" });
+      const state = makeState([patient]);
+      const lab: LabEntry = {
+        id: "lab-1",
+        label: "Cr",
+        value: 1.5,
+        unit: "mg/dL",
+        time: "2025-01-01T08:00:00Z",
+      };
+
+      const next = reducer(state, { type: "ADD_LAB", patientId: "p1", lab });
+      expect(next.patients[0].labs).toHaveLength(1);
+      expect(next.patients[0].labs![0].label).toBe("Cr");
+    });
+  });
+
+  describe("REORDER_PATIENT", () => {
+    it("moves a patient up within their section", () => {
+      const p1 = makePatient({ id: "p1", section: "SIDE_A", order: 0 });
+      const p2 = makePatient({ id: "p2", section: "SIDE_A", order: 1 });
+      const state = makeState([p1, p2]);
+
+      const next = reducer(state, {
+        type: "REORDER_PATIENT",
+        patientId: "p2",
+        direction: "up",
+      });
+      expect(next.patients.find((p) => p.id === "p2")!.order).toBe(0);
+      expect(next.patients.find((p) => p.id === "p1")!.order).toBe(1);
+    });
+
+    it("does not move first patient up", () => {
+      const p1 = makePatient({ id: "p1", section: "SIDE_A", order: 0 });
+      const state = makeState([p1]);
+
+      const next = reducer(state, {
+        type: "REORDER_PATIENT",
+        patientId: "p1",
+        direction: "up",
+      });
+      expect(next.patients[0].order).toBe(0);
+    });
+
+    it("does not affect patients in other sections", () => {
+      const p1 = makePatient({ id: "p1", section: "SIDE_A", order: 0 });
+      const p2 = makePatient({ id: "p2", section: "SIDE_B", order: 0 });
+      const state = makeState([p1, p2]);
+
+      const next = reducer(state, {
+        type: "REORDER_PATIENT",
+        patientId: "p1",
+        direction: "down",
+      });
+      // p1 is the only patient in SIDE_A, so no swap happens
+      expect(next.patients.find((p) => p.id === "p1")!.order).toBe(0);
+    });
+  });
+
+  describe("EDIT_PATIENT", () => {
+    it("updates patient name", () => {
+      const patient = makePatient({ id: "p1", name: "Old Name" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "EDIT_PATIENT",
+        patientId: "p1",
+        name: "New Name",
+      });
+      expect(next.patients[0].name).toBe("New Name");
+    });
+
+    it("updates patient room", () => {
+      const patient = makePatient({ id: "p1", room: "101" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "EDIT_PATIENT",
+        patientId: "p1",
+        room: "202",
+      });
+      expect(next.patients[0].room).toBe("202");
+    });
+
+    it("updates patient section", () => {
+      const patient = makePatient({ id: "p1", section: "SIDE_A" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "EDIT_PATIENT",
+        patientId: "p1",
+        section: "SIDE_B",
+      });
+      expect(next.patients[0].section).toBe("SIDE_B");
+    });
+
+    it("updates diagnosis", () => {
+      const patient = makePatient({ id: "p1", diagnosis: null });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "EDIT_PATIENT",
+        patientId: "p1",
+        diagnosis: "דלקת ריאות",
+      });
+      expect(next.patients[0].diagnosis).toBe("דלקת ריאות");
+    });
+
+    it("does not modify unspecified fields", () => {
+      const patient = makePatient({ id: "p1", name: "Test", room: "101", diagnosis: "DM" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, {
+        type: "EDIT_PATIENT",
+        patientId: "p1",
+        name: "Updated",
+      });
+      expect(next.patients[0].name).toBe("Updated");
+      expect(next.patients[0].room).toBe("101");
+      expect(next.patients[0].diagnosis).toBe("DM");
+    });
+  });
+
+  describe("REMOVE_PATIENT", () => {
+    it("removes the correct patient", () => {
+      const p1 = makePatient({ id: "p1" });
+      const p2 = makePatient({ id: "p2" });
+      const state = makeState([p1, p2]);
+
+      const next = reducer(state, { type: "REMOVE_PATIENT", patientId: "p1" });
+      expect(next.patients).toHaveLength(1);
+      expect(next.patients[0].id).toBe("p2");
+    });
+
+    it("does nothing for non-existent patient", () => {
+      const patient = makePatient({ id: "p1" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, { type: "REMOVE_PATIENT", patientId: "p999" });
+      expect(next.patients).toHaveLength(1);
+    });
+  });
+
+  describe("ARCHIVE_SHIFT", () => {
+    it("creates a shift snapshot", () => {
+      const patient = makePatient({ id: "p1" });
+      const state = makeState([patient]);
+
+      const next = reducer(state, { type: "ARCHIVE_SHIFT", label: "19/02 — ערב" });
+      expect(next.shiftHistory).toHaveLength(1);
+      expect(next.shiftHistory[0].label).toBe("19/02 — ערב");
+      expect(next.shiftHistory[0].patients).toHaveLength(1);
+    });
+
+    it("limits history to 5 shifts", () => {
+      const state = makeState([], {
+        shiftHistory: Array.from({ length: 5 }, (_, i) => ({
+          id: `shift-${i}`,
+          date: "2025-01-01",
+          label: `Shift ${i}`,
+          patients: [],
+          archivedAt: "2025-01-01T00:00:00Z",
+        })),
+      });
+
+      const next = reducer(state, { type: "ARCHIVE_SHIFT", label: "New Shift" });
+      expect(next.shiftHistory).toHaveLength(5);
+      expect(next.shiftHistory[0].label).toBe("New Shift");
+    });
+
+    it("newest shift is first in array", () => {
+      const state = makeState([], {
+        shiftHistory: [
+          { id: "old", date: "2025-01-01", label: "Old", patients: [], archivedAt: "2025-01-01" },
+        ],
+      });
+
+      const next = reducer(state, { type: "ARCHIVE_SHIFT", label: "New" });
+      expect(next.shiftHistory[0].label).toBe("New");
+      expect(next.shiftHistory[1].label).toBe("Old");
+    });
+  });
+
+  describe("RESTORE_SHIFT", () => {
+    it("restores patients from a snapshot", () => {
+      const archivedPatient = makePatient({ id: "archived-1", name: "Archived" });
+      const state = makeState([makePatient({ id: "current-1" })], {
+        shiftHistory: [
+          {
+            id: "snap-1",
+            date: "2025-01-01",
+            label: "Old shift",
+            patients: [archivedPatient],
+            archivedAt: "2025-01-01T00:00:00Z",
+          },
+        ],
+      });
+
+      const next = reducer(state, { type: "RESTORE_SHIFT", snapshotId: "snap-1" });
+      expect(next.patients).toHaveLength(1);
+      expect(next.patients[0].name).toBe("Archived");
+    });
+
+    it("does nothing for non-existent snapshot", () => {
+      const state = makeState([makePatient({ id: "p1" })]);
+      const next = reducer(state, { type: "RESTORE_SHIFT", snapshotId: "nope" });
+      expect(next.patients).toHaveLength(1);
+      expect(next.patients[0].id).toBe("p1");
+    });
+  });
+
+  describe("DELETE_SHIFT", () => {
+    it("removes the correct shift", () => {
+      const state = makeState([], {
+        shiftHistory: [
+          { id: "s1", date: "d", label: "Shift 1", patients: [], archivedAt: "d" },
+          { id: "s2", date: "d", label: "Shift 2", patients: [], archivedAt: "d" },
+        ],
+      });
+
+      const next = reducer(state, { type: "DELETE_SHIFT", snapshotId: "s1" });
+      expect(next.shiftHistory).toHaveLength(1);
+      expect(next.shiftHistory[0].id).toBe("s2");
+    });
+  });
+
+  describe("TOGGLE_DARK_MODE", () => {
+    it("toggles dark mode on", () => {
+      const state = makeState([], { darkMode: false });
+      const next = reducer(state, { type: "TOGGLE_DARK_MODE" });
+      expect(next.darkMode).toBe(true);
+    });
+
+    it("toggles dark mode off", () => {
+      const state = makeState([], { darkMode: true });
+      const next = reducer(state, { type: "TOGGLE_DARK_MODE" });
+      expect(next.darkMode).toBe(false);
+    });
+  });
+
+  describe("TOGGLE_SHOW_TOMORROW", () => {
+    it("toggles showTomorrow", () => {
+      const state = makeState([], { showTomorrow: false });
+      const next = reducer(state, { type: "TOGGLE_SHOW_TOMORROW" });
+      expect(next.showTomorrow).toBe(true);
+    });
+  });
+
+  describe("CLEAR_ALL", () => {
+    it("empties the patients array", () => {
+      const state = makeState([makePatient(), makePatient({ id: "p2" })]);
+      const next = reducer(state, { type: "CLEAR_ALL" });
+      expect(next.patients).toHaveLength(0);
+    });
+
+    it("preserves other state fields", () => {
+      const state = makeState([makePatient()], { darkMode: true, activeSection: "SIDE_B" });
+      const next = reducer(state, { type: "CLEAR_ALL" });
+      expect(next.darkMode).toBe(true);
+      expect(next.activeSection).toBe("SIDE_B");
+    });
+  });
+
+  describe("IMPORT_TEXT", () => {
+    it("parses and adds patients from text", () => {
+      const state = makeState();
+      const next = reducer(state, {
+        type: "IMPORT_TEXT",
+        text: "101 כהן יוסף 72 דלקת ריאות",
+      });
+      expect(next.patients.length).toBeGreaterThanOrEqual(1);
+      expect(next.patients[0].name).toBe("כהן יוסף");
+    });
+
+    it("merges with existing patients on rescan", () => {
+      const state = makeState();
+      const first = reducer(state, {
+        type: "IMPORT_TEXT",
+        text: "101 כהן יוסף 72",
+      });
+      const originalId = first.patients[0].id;
+
+      const second = reducer(first, {
+        type: "IMPORT_TEXT",
+        text: "101 כהן יוסף 72",
+      });
+      expect(second.patients).toHaveLength(1);
+      expect(second.patients[0].id).toBe(originalId);
+    });
+  });
+});

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -1,33 +1,739 @@
 import { describe, it, expect } from "vitest";
-import { parsePatientList } from "../parser/parsePatientList";
+import { applyRules, RULES } from "../engine/rules";
+import type { PatientEntry, Task } from "../types";
 
-describe("rules engine - BS (Bladder Scan)", () => {
-  it('"BS בערב" generates a BS (Bladder Scan) generated task', () => {
-    const result = parsePatientList("101 כהן יוסף 72 | BS בערב");
-    expect(result).toHaveLength(1);
+/** Build a minimal PatientEntry for testing rules. */
+function makePatient(overrides: {
+  diagnosis?: string;
+  flags?: string[];
+  status?: string[];
+  tasks?: Array<{ text: string }>;
+}): PatientEntry {
+  return {
+    id: "test-pt",
+    section: "SIDE_A",
+    date: "01/01/2025",
+    room: "101",
+    name: "Test Patient",
+    age: 60,
+    diagnosis: overrides.diagnosis ?? null,
+    flags: overrides.flags ?? [],
+    status: overrides.status ?? [],
+    tomorrowNotes: [],
+    tasks: (overrides.tasks ?? []).map((t) => ({
+      id: "t-1",
+      text: t.text,
+      urgency: "routine" as const,
+      source: "extracted" as const,
+      done: false,
+      doneTime: null,
+      time: null,
+      confidence: 1,
+    })),
+    generatedTasks: [],
+    notes: [],
+    scannedAt: new Date().toISOString(),
+    confidence: 1,
+  };
+}
 
-    // The task text "BS בערב" triggers the BS rule via applyRules
-    const genTasks = result[0].generatedTasks;
-    const bsTask = genTasks.find((t) => t.text.includes("Bladder Scan"));
-    expect(bsTask).toBeDefined();
-    expect(bsTask!.generatedFrom).toBe("BS (Bladder Scan)");
-    expect(bsTask!.source).toBe("generated");
+function generatedSources(tasks: Task[]): string[] {
+  return [...new Set(tasks.map((t) => t.generatedFrom!))];
+}
+
+// ─── Individual rule trigger tests ───
+
+describe("rules engine — all rules", () => {
+  // 1. Discharge
+  describe("Discharge", () => {
+    it("triggers on 'משתחרר'", () => {
+      const tasks = applyRules(makePatient({ status: ["משתחרר היום"] }));
+      expect(generatedSources(tasks)).toContain("שחרור");
+    });
+
+    it("triggers on 'D/C'", () => {
+      const tasks = applyRules(makePatient({ status: ["D/C today"] }));
+      expect(generatedSources(tasks)).toContain("שחרור");
+    });
+
+    it("triggers on 'discharge'", () => {
+      const tasks = applyRules(makePatient({ status: ["discharge planned"] }));
+      expect(generatedSources(tasks)).toContain("שחרור");
+    });
+
+    it("generates 4 discharge tasks", () => {
+      const tasks = applyRules(makePatient({ status: ["משתחרר"] }));
+      const dischargeTasks = tasks.filter((t) => t.generatedFrom === "שחרור");
+      expect(dischargeTasks).toHaveLength(4);
+    });
+
+    it("discharge tasks have correct categories", () => {
+      const tasks = applyRules(makePatient({ status: ["משתחרר"] }));
+      const dischargeTasks = tasks.filter((t) => t.generatedFrom === "שחרור");
+      expect(dischargeTasks.every((t) => t.category === "discharge")).toBe(true);
+    });
   });
 
-  it('"BS בערב" extracted task is categorized as procedure', () => {
-    const result = parsePatientList("101 כהן יוסף 72 | BS בערב");
-    const extractedTask = result[0].tasks.find((t) => t.text === "BS בערב");
-    expect(extractedTask).toBeDefined();
-    expect(extractedTask!.category).toBe("procedure");
+  // 2. NPO
+  describe("NPO", () => {
+    it("triggers on 'NPO' flag", () => {
+      const tasks = applyRules(makePatient({ flags: ["NPO"] }));
+      expect(generatedSources(tasks)).toContain("NPO");
+    });
+
+    it("generates 2 NPO tasks", () => {
+      const tasks = applyRules(makePatient({ flags: ["NPO"] }));
+      const npoTasks = tasks.filter((t) => t.generatedFrom === "NPO");
+      expect(npoTasks).toHaveLength(2);
+    });
+
+    it("does NOT trigger on 'NPORT' (word boundary)", () => {
+      const tasks = applyRules(makePatient({ status: ["NPORT device"] }));
+      expect(generatedSources(tasks)).not.toContain("NPO");
+    });
   });
 
-  it("BS is NOT confused with blood sugar/DM rule", () => {
-    const result = parsePatientList("101 כהן יוסף 72 | BS בערב");
-    const genTasks = result[0].generatedTasks;
-    // Should NOT trigger the diabetes/sugar rule
-    const sugarTask = genTasks.find(
-      (t) => t.generatedFrom === "סוכרת",
+  // 3. Pre-op
+  describe("Pre-op", () => {
+    it("triggers on 'ניתוח'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "לפני ניתוח" }));
+      expect(generatedSources(tasks)).toContain("טרום ניתוח");
+    });
+
+    it("triggers on 'pre-op'", () => {
+      const tasks = applyRules(makePatient({ status: ["pre-op workup"] }));
+      expect(generatedSources(tasks)).toContain("טרום ניתוח");
+    });
+
+    it("generates 4 pre-op tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "ניתוח" }));
+      const preopTasks = tasks.filter((t) => t.generatedFrom === "טרום ניתוח");
+      expect(preopTasks).toHaveLength(4);
+    });
+  });
+
+  // 4. Blood products / transfusion
+  describe("Blood products", () => {
+    it("triggers on 'עירוי דם'", () => {
+      const tasks = applyRules(makePatient({ status: ["עירוי דם"] }));
+      expect(generatedSources(tasks)).toContain("עירוי דם");
+    });
+
+    it("triggers on 'PRBCs'", () => {
+      const tasks = applyRules(makePatient({ status: ["2 PRBCs ordered"] }));
+      expect(generatedSources(tasks)).toContain("עירוי דם");
+    });
+
+    it("triggers on 'packed cells'", () => {
+      const tasks = applyRules(makePatient({ status: ["packed cells"] }));
+      expect(generatedSources(tasks)).toContain("עירוי דם");
+    });
+
+    it("generates 4 transfusion tasks", () => {
+      const tasks = applyRules(makePatient({ status: ["מנת דם"] }));
+      const transTasks = tasks.filter((t) => t.generatedFrom === "עירוי דם");
+      expect(transTasks).toHaveLength(4);
+    });
+  });
+
+  // 5. Diabetes
+  describe("Diabetes", () => {
+    it("triggers on 'סוכרת'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "סוכרת סוג 2" }));
+      expect(generatedSources(tasks)).toContain("סוכרת");
+    });
+
+    it("triggers on 'DM2'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "DM2" }));
+      expect(generatedSources(tasks)).toContain("סוכרת");
+    });
+
+    it("triggers on 'insulin'", () => {
+      const tasks = applyRules(makePatient({ status: ["insulin sliding scale"] }));
+      expect(generatedSources(tasks)).toContain("סוכרת");
+    });
+
+    it("does NOT trigger on 'DM' followed by a word char (e.g. DMG)", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "DMG test" }));
+      expect(generatedSources(tasks)).not.toContain("סוכרת");
+    });
+
+    it("generates 3 diabetes tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "סוכרת" }));
+      const dmTasks = tasks.filter((t) => t.generatedFrom === "סוכרת");
+      expect(dmTasks).toHaveLength(3);
+    });
+  });
+
+  // 6. Fall risk
+  describe("Fall risk", () => {
+    it("triggers on 'נפילה'", () => {
+      const tasks = applyRules(makePatient({ status: ["נפילה"] }));
+      expect(generatedSources(tasks)).toContain("סיכון נפילה");
+    });
+
+    it("triggers on 'FALL' flag", () => {
+      const tasks = applyRules(makePatient({ flags: ["FALL"] }));
+      expect(generatedSources(tasks)).toContain("סיכון נפילה");
+    });
+
+    it("generates 3 fall tasks", () => {
+      const tasks = applyRules(makePatient({ flags: ["FALL"] }));
+      const fallTasks = tasks.filter((t) => t.generatedFrom === "סיכון נפילה");
+      expect(fallTasks).toHaveLength(3);
+    });
+  });
+
+  // 7. Bladder Scan (BS)
+  describe("BS (Bladder Scan)", () => {
+    it("triggers on 'BS' in task text", () => {
+      const tasks = applyRules(makePatient({ tasks: [{ text: "BS בערב" }] }));
+      expect(generatedSources(tasks)).toContain("BS (Bladder Scan)");
+    });
+
+    it("triggers on 'Bladder Scan'", () => {
+      const tasks = applyRules(makePatient({ status: ["Bladder Scan needed"] }));
+      expect(generatedSources(tasks)).toContain("BS (Bladder Scan)");
+    });
+
+    it("BS is NOT confused with blood sugar / DM rule", () => {
+      const tasks = applyRules(makePatient({ tasks: [{ text: "BS בערב" }] }));
+      expect(generatedSources(tasks)).not.toContain("סוכרת");
+    });
+
+    it("generates 1 BS task", () => {
+      const tasks = applyRules(makePatient({ tasks: [{ text: "BS" }] }));
+      const bsTasks = tasks.filter((t) => t.generatedFrom === "BS (Bladder Scan)");
+      expect(bsTasks).toHaveLength(1);
+      expect(bsTasks[0].category).toBe("procedure");
+    });
+  });
+
+  // 8. Isolation
+  describe("Isolation", () => {
+    it("triggers on 'בידוד'", () => {
+      const tasks = applyRules(makePatient({ status: ["בידוד מגע"] }));
+      expect(generatedSources(tasks)).toContain("בידוד");
+    });
+
+    it("triggers on 'MRSA' flag", () => {
+      const tasks = applyRules(makePatient({ flags: ["MRSA"] }));
+      expect(generatedSources(tasks)).toContain("בידוד");
+    });
+
+    it("triggers on 'VRE'", () => {
+      const tasks = applyRules(makePatient({ flags: ["VRE"] }));
+      expect(generatedSources(tasks)).toContain("בידוד");
+    });
+
+    it("generates 3 isolation tasks", () => {
+      const tasks = applyRules(makePatient({ status: ["בידוד"] }));
+      const isoTasks = tasks.filter((t) => t.generatedFrom === "בידוד");
+      expect(isoTasks).toHaveLength(3);
+    });
+  });
+
+  // 9. Catheter
+  describe("Catheter", () => {
+    it("triggers on 'קטטר'", () => {
+      const tasks = applyRules(makePatient({ status: ["קטטר שתן"] }));
+      expect(generatedSources(tasks)).toContain("קטטר שתן");
+    });
+
+    it("triggers on 'foley'", () => {
+      const tasks = applyRules(makePatient({ status: ["foley catheter"] }));
+      expect(generatedSources(tasks)).toContain("קטטר שתן");
+    });
+
+    it("does NOT trigger on 'קטטר חד' (one-time catheter)", () => {
+      const tasks = applyRules(makePatient({ status: ["קטטר חד פעמי"] }));
+      expect(generatedSources(tasks)).not.toContain("קטטר שתן");
+    });
+
+    it("generates 2 catheter tasks", () => {
+      const tasks = applyRules(makePatient({ status: ["foley"] }));
+      const catTasks = tasks.filter((t) => t.generatedFrom === "קטטר שתן");
+      expect(catTasks).toHaveLength(2);
+    });
+  });
+
+  // 10. Pneumonia
+  describe("Pneumonia", () => {
+    it("triggers on 'דלקת ריאות'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "דלקת ריאות" }));
+      expect(generatedSources(tasks)).toContain("דלקת ריאות");
+    });
+
+    it("triggers on 'pneumonia'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "pneumonia" }));
+      expect(generatedSources(tasks)).toContain("דלקת ריאות");
+    });
+
+    it("triggers on 'CAP'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "CAP" }));
+      expect(generatedSources(tasks)).toContain("דלקת ריאות");
+    });
+
+    it("generates 6 pneumonia tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "דלקת ריאות" }));
+      const pnTasks = tasks.filter((t) => t.generatedFrom === "דלקת ריאות");
+      expect(pnTasks).toHaveLength(6);
+    });
+  });
+
+  // 11. UTI
+  describe("UTI", () => {
+    it("triggers on 'UTI'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "UTI" }));
+      expect(generatedSources(tasks)).toContain("זיהום בדרכי השתן");
+    });
+
+    it("triggers on 'דלקת בדרכי השתן'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "דלקת בדרכי השתן" }));
+      expect(generatedSources(tasks)).toContain("זיהום בדרכי השתן");
+    });
+
+    it("generates 4 UTI tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "UTI" }));
+      const utiTasks = tasks.filter((t) => t.generatedFrom === "זיהום בדרכי השתן");
+      expect(utiTasks).toHaveLength(4);
+    });
+  });
+
+  // 12. Sepsis
+  describe("Sepsis", () => {
+    it("triggers on 'ספסיס'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "ספסיס" }));
+      expect(generatedSources(tasks)).toContain("ספסיס");
+    });
+
+    it("triggers on 'sepsis'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "sepsis" }));
+      expect(generatedSources(tasks)).toContain("ספסיס");
+    });
+
+    it("triggers on 'bacteremia'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "bacteremia" }));
+      expect(generatedSources(tasks)).toContain("ספסיס");
+    });
+
+    it("generates 7 sepsis tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "ספסיס" }));
+      const sepTasks = tasks.filter((t) => t.generatedFrom === "ספסיס");
+      expect(sepTasks).toHaveLength(7);
+    });
+  });
+
+  // 13. Cellulitis
+  describe("Cellulitis", () => {
+    it("triggers on 'צלוליטיס'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "צלוליטיס" }));
+      expect(generatedSources(tasks)).toContain("צלוליטיס");
+    });
+
+    it("triggers on 'cellulitis'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "cellulitis" }));
+      expect(generatedSources(tasks)).toContain("צלוליטיס");
+    });
+
+    it("generates 4 cellulitis tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "צלוליטיס" }));
+      const cellTasks = tasks.filter((t) => t.generatedFrom === "צלוליטיס");
+      expect(cellTasks).toHaveLength(4);
+    });
+  });
+
+  // 14. C. difficile
+  describe("C. difficile", () => {
+    it("triggers on 'C diff'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "C diff infection" }));
+      expect(generatedSources(tasks)).toContain("חשד C. difficile");
+    });
+
+    it("triggers on 'קלוסטרידיום'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "קלוסטרידיום" }));
+      expect(generatedSources(tasks)).toContain("חשד C. difficile");
+    });
+
+    it("generates 4 C. diff tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "clostridium" }));
+      const cdTasks = tasks.filter((t) => t.generatedFrom === "חשד C. difficile");
+      expect(cdTasks).toHaveLength(4);
+    });
+  });
+
+  // 15. Fever
+  describe("Fever", () => {
+    it("triggers on 'חום'", () => {
+      const tasks = applyRules(makePatient({ status: ["חום 38.8"] }));
+      expect(generatedSources(tasks)).toContain("חום — בירור");
+    });
+
+    it("triggers on 'fever'", () => {
+      const tasks = applyRules(makePatient({ status: ["fever workup"] }));
+      expect(generatedSources(tasks)).toContain("חום — בירור");
+    });
+
+    it("triggers on '39.2' (temperature value)", () => {
+      const tasks = applyRules(makePatient({ status: ["39.2 degrees"] }));
+      expect(generatedSources(tasks)).toContain("חום — בירור");
+    });
+
+    it("generates 5 fever tasks", () => {
+      const tasks = applyRules(makePatient({ status: ["חום"] }));
+      const fvTasks = tasks.filter((t) => t.generatedFrom === "חום — בירור");
+      expect(fvTasks).toHaveLength(5);
+    });
+  });
+
+  // 16. AKI
+  describe("AKI", () => {
+    it("triggers on 'AKI'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "AKI" }));
+      expect(generatedSources(tasks)).toContain("AKI");
+    });
+
+    it("triggers on 'acute kidney'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "acute kidney injury" }));
+      expect(generatedSources(tasks)).toContain("AKI");
+    });
+
+    it("generates 6 AKI tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "AKI" }));
+      const akiTasks = tasks.filter((t) => t.generatedFrom === "AKI");
+      expect(akiTasks).toHaveLength(6);
+    });
+  });
+
+  // 17. Hyperkalemia
+  describe("Hyperkalemia", () => {
+    it("triggers on 'היפרקלמיה'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "היפרקלמיה" }));
+      expect(generatedSources(tasks)).toContain("היפרקלמיה");
+    });
+
+    it("triggers on 'hyperkalemia'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "hyperkalemia" }));
+      expect(generatedSources(tasks)).toContain("היפרקלמיה");
+    });
+
+    it("generates 6 hyperkalemia tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "היפרקלמיה" }));
+      const hkTasks = tasks.filter((t) => t.generatedFrom === "היפרקלמיה");
+      expect(hkTasks).toHaveLength(6);
+    });
+  });
+
+  // 18. Hypokalemia
+  describe("Hypokalemia", () => {
+    it("triggers on 'היפוקלמיה'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "היפוקלמיה" }));
+      expect(generatedSources(tasks)).toContain("היפוקלמיה");
+    });
+
+    it("triggers on 'hypokalemia'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "hypokalemia" }));
+      expect(generatedSources(tasks)).toContain("היפוקלמיה");
+    });
+
+    it("generates 5 hypokalemia tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "היפוקלמיה" }));
+      const lkTasks = tasks.filter((t) => t.generatedFrom === "היפוקלמיה");
+      expect(lkTasks).toHaveLength(5);
+    });
+  });
+
+  // 19. Chest pain / ACS
+  describe("Chest pain / ACS", () => {
+    it("triggers on 'כאב בחזה'", () => {
+      const tasks = applyRules(makePatient({ status: ["כאב בחזה"] }));
+      expect(generatedSources(tasks)).toContain("כאב חזה / ACS");
+    });
+
+    it("triggers on 'STEMI'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "STEMI" }));
+      expect(generatedSources(tasks)).toContain("כאב חזה / ACS");
+    });
+
+    it("triggers on 'chest pain'", () => {
+      const tasks = applyRules(makePatient({ status: ["chest pain"] }));
+      expect(generatedSources(tasks)).toContain("כאב חזה / ACS");
+    });
+
+    it("generates 7 ACS tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "STEMI" }));
+      const acsTasks = tasks.filter((t) => t.generatedFrom === "כאב חזה / ACS");
+      expect(acsTasks).toHaveLength(7);
+    });
+  });
+
+  // 20. CHF
+  describe("CHF / Heart failure", () => {
+    it("triggers on 'אי ספיקת לב'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "אי ספיקת לב" }));
+      expect(generatedSources(tasks)).toContain("אי-ספיקת לב");
+    });
+
+    it("triggers on 'CHF'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "CHF" }));
+      expect(generatedSources(tasks)).toContain("אי-ספיקת לב");
+    });
+
+    it("triggers on 'pulmonary edema'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "pulmonary edema" }));
+      expect(generatedSources(tasks)).toContain("אי-ספיקת לב");
+    });
+
+    it("generates 6 CHF tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "CHF" }));
+      const chfTasks = tasks.filter((t) => t.generatedFrom === "אי-ספיקת לב");
+      expect(chfTasks).toHaveLength(6);
+    });
+  });
+
+  // 21. DVT / PE
+  describe("DVT / PE", () => {
+    it("triggers on 'DVT'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "DVT" }));
+      expect(generatedSources(tasks)).toContain("DVT / PE");
+    });
+
+    it("triggers on 'תסחיף ריאתי'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "תסחיף ריאתי" }));
+      expect(generatedSources(tasks)).toContain("DVT / PE");
+    });
+
+    it("generates 5 DVT/PE tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "DVT" }));
+      const dvtTasks = tasks.filter((t) => t.generatedFrom === "DVT / PE");
+      expect(dvtTasks).toHaveLength(5);
+    });
+  });
+
+  // 22. Delirium
+  describe("Delirium", () => {
+    it("triggers on 'דליריום'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "דליריום" }));
+      expect(generatedSources(tasks)).toContain("דליריום");
+    });
+
+    it("triggers on 'delirium'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "delirium" }));
+      expect(generatedSources(tasks)).toContain("דליריום");
+    });
+
+    it("triggers on 'acute confusion'", () => {
+      const tasks = applyRules(makePatient({ status: ["acute confusion"] }));
+      expect(generatedSources(tasks)).toContain("דליריום");
+    });
+
+    it("generates 7 delirium tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "דליריום" }));
+      const delTasks = tasks.filter((t) => t.generatedFrom === "דליריום");
+      expect(delTasks).toHaveLength(7);
+    });
+  });
+
+  // 23. GI Bleed
+  describe("GI Bleed", () => {
+    it("triggers on 'GI bleed'", () => {
+      const tasks = applyRules(makePatient({ status: ["GI bleed"] }));
+      expect(generatedSources(tasks)).toContain("דימום GI");
+    });
+
+    it("triggers on 'מלנה'", () => {
+      const tasks = applyRules(makePatient({ status: ["מלנה"] }));
+      expect(generatedSources(tasks)).toContain("דימום GI");
+    });
+
+    it("triggers on 'hematemesis'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "hematemesis" }));
+      expect(generatedSources(tasks)).toContain("דימום GI");
+    });
+
+    it("generates 8 GI bleed tasks", () => {
+      const tasks = applyRules(makePatient({ status: ["GI bleed"] }));
+      const giTasks = tasks.filter((t) => t.generatedFrom === "דימום GI");
+      expect(giTasks).toHaveLength(8);
+    });
+  });
+
+  // 24. Warfarin / INR
+  describe("Warfarin / INR", () => {
+    it("triggers on 'warfarin'", () => {
+      const tasks = applyRules(makePatient({ status: ["on warfarin"] }));
+      expect(generatedSources(tasks)).toContain("Warfarin / INR");
+    });
+
+    it("triggers on 'קומדין'", () => {
+      const tasks = applyRules(makePatient({ status: ["קומדין"] }));
+      expect(generatedSources(tasks)).toContain("Warfarin / INR");
+    });
+
+    it("generates 4 warfarin tasks", () => {
+      const tasks = applyRules(makePatient({ status: ["warfarin"] }));
+      const warTasks = tasks.filter((t) => t.generatedFrom === "Warfarin / INR");
+      expect(warTasks).toHaveLength(4);
+    });
+  });
+
+  // 25. COPD
+  describe("COPD exacerbation", () => {
+    it("triggers on 'COPD החמרה'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "COPD החמרה" }));
+      expect(generatedSources(tasks)).toContain("החמרת COPD");
+    });
+
+    it("triggers on 'AECOPD'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "AECOPD" }));
+      expect(generatedSources(tasks)).toContain("החמרת COPD");
+    });
+
+    it("generates 6 COPD tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "COPD החמרה" }));
+      const copdTasks = tasks.filter((t) => t.generatedFrom === "החמרת COPD");
+      expect(copdTasks).toHaveLength(6);
+    });
+  });
+
+  // 26. Hypoglycemia
+  describe("Hypoglycemia", () => {
+    it("triggers on 'היפוגליקמיה'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "היפוגליקמיה" }));
+      expect(generatedSources(tasks)).toContain("היפוגליקמיה");
+    });
+
+    it("triggers on 'hypoglycemia'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "hypoglycemia" }));
+      expect(generatedSources(tasks)).toContain("היפוגליקמיה");
+    });
+
+    it("generates 3 hypoglycemia tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "היפוגליקמיה" }));
+      const hypoTasks = tasks.filter((t) => t.generatedFrom === "היפוגליקמיה");
+      expect(hypoTasks).toHaveLength(3);
+    });
+  });
+
+  // 27. New admission
+  describe("New admission", () => {
+    it("triggers on 'קבלה חדשה'", () => {
+      const tasks = applyRules(makePatient({ status: ["קבלה חדשה"] }));
+      expect(generatedSources(tasks)).toContain("קבלה חדשה");
+    });
+
+    it("triggers on 'new admission'", () => {
+      const tasks = applyRules(makePatient({ status: ["new admission"] }));
+      expect(generatedSources(tasks)).toContain("קבלה חדשה");
+    });
+
+    it("generates 6 new admission tasks", () => {
+      const tasks = applyRules(makePatient({ status: ["קבלה חדשה"] }));
+      const admTasks = tasks.filter((t) => t.generatedFrom === "קבלה חדשה");
+      expect(admTasks).toHaveLength(6);
+    });
+  });
+
+  // 28. Hyponatremia
+  describe("Hyponatremia", () => {
+    it("triggers on 'היפונתרמיה'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "היפונתרמיה" }));
+      expect(generatedSources(tasks)).toContain("היפונתרמיה");
+    });
+
+    it("triggers on 'hyponatremia'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "hyponatremia" }));
+      expect(generatedSources(tasks)).toContain("היפונתרמיה");
+    });
+
+    it("generates 5 hyponatremia tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "היפונתרמיה" }));
+      const naTasks = tasks.filter((t) => t.generatedFrom === "היפונתרמיה");
+      expect(naTasks).toHaveLength(5);
+    });
+  });
+
+  // 29. Stroke / TIA
+  describe("Stroke / TIA", () => {
+    it("triggers on 'שבץ'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "שבץ" }));
+      expect(generatedSources(tasks)).toContain("שבץ / TIA");
+    });
+
+    it("triggers on 'CVA'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "CVA" }));
+      expect(generatedSources(tasks)).toContain("שבץ / TIA");
+    });
+
+    it("triggers on 'TIA'", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "TIA" }));
+      expect(generatedSources(tasks)).toContain("שבץ / TIA");
+    });
+
+    it("generates 7 stroke tasks", () => {
+      const tasks = applyRules(makePatient({ diagnosis: "שבץ" }));
+      const strTasks = tasks.filter((t) => t.generatedFrom === "שבץ / TIA");
+      expect(strTasks).toHaveLength(7);
+    });
+  });
+});
+
+// ─── Cross-cutting rule behavior ───
+
+describe("rules engine — cross-cutting behavior", () => {
+  it("all generated tasks have source='generated'", () => {
+    const tasks = applyRules(makePatient({ diagnosis: "ספסיס", flags: ["NPO", "FALL"] }));
+    expect(tasks.length).toBeGreaterThan(0);
+    for (const t of tasks) {
+      expect(t.source).toBe("generated");
+    }
+  });
+
+  it("all generated tasks have a generatedFrom field", () => {
+    const tasks = applyRules(makePatient({ diagnosis: "דלקת ריאות" }));
+    for (const t of tasks) {
+      expect(t.generatedFrom).toBeDefined();
+      expect(t.generatedFrom!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all generated tasks have valid urgency", () => {
+    const tasks = applyRules(makePatient({ diagnosis: "ספסיס" }));
+    const validUrgencies = ["stat", "urgent", "morning", "routine", "extra"];
+    for (const t of tasks) {
+      expect(validUrgencies).toContain(t.urgency);
+    }
+  });
+
+  it("group dedup: same group triggered twice produces only one set", () => {
+    // "cellulitis" and "דלקת בעור" both match the cellulitis group
+    const tasks = applyRules(
+      makePatient({ diagnosis: "cellulitis", status: ["דלקת בעור"] }),
     );
-    expect(sugarTask).toBeUndefined();
+    const cellTasks = tasks.filter((t) => t.generatedFrom === "צלוליטיס");
+    expect(cellTasks).toHaveLength(4); // exactly one set
+  });
+
+  it("multiple conditions generate tasks from each rule", () => {
+    const tasks = applyRules(
+      makePatient({ diagnosis: "סוכרת", flags: ["NPO"] }),
+    );
+    const sources = generatedSources(tasks);
+    expect(sources).toContain("סוכרת");
+    expect(sources).toContain("NPO");
+  });
+
+  it("patient with no matching conditions generates no tasks", () => {
+    const tasks = applyRules(makePatient({}));
+    expect(tasks).toHaveLength(0);
+  });
+
+  it("RULES array has expected number of rules", () => {
+    expect(RULES.length).toBe(29);
+  });
+
+  it("every rule has a unique group", () => {
+    const groups = RULES.map((r) => r.group).filter(Boolean);
+    expect(new Set(groups).size).toBe(groups.length);
   });
 });

--- a/src/__tests__/sectionDetection.test.ts
+++ b/src/__tests__/sectionDetection.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { detectSectionFromHeader, detectSectionFromRoom } from "../types/patient";
+
+describe("detectSectionFromHeader", () => {
+  // Hebrew section names
+  it('returns SIDE_A for "צד א"', () => {
+    expect(detectSectionFromHeader("צד א")).toBe("SIDE_A");
+  });
+
+  it('returns SIDE_B for "צד ב"', () => {
+    expect(detectSectionFromHeader("צד ב")).toBe("SIDE_B");
+  });
+
+  it('returns SIDE_C for "צד ג"', () => {
+    expect(detectSectionFromHeader("צד ג")).toBe("SIDE_C");
+  });
+
+  it('returns REHAB for "שיקום"', () => {
+    expect(detectSectionFromHeader("שיקום")).toBe("REHAB");
+  });
+
+  it('returns REHAB for "שיקומי"', () => {
+    expect(detectSectionFromHeader("שיקומי")).toBe("REHAB");
+  });
+
+  it('returns MONITOR for "ניטור"', () => {
+    expect(detectSectionFromHeader("ניטור")).toBe("MONITOR");
+  });
+
+  it('returns MONITOR for "מוניטור"', () => {
+    expect(detectSectionFromHeader("מוניטור")).toBe("MONITOR");
+  });
+
+  it('returns MONITOR for "מוניטורים"', () => {
+    expect(detectSectionFromHeader("מוניטורים")).toBe("MONITOR");
+  });
+
+  // English variants
+  it('returns SIDE_A for "side a"', () => {
+    expect(detectSectionFromHeader("side a")).toBe("SIDE_A");
+  });
+
+  it('returns SIDE_B for "side b"', () => {
+    expect(detectSectionFromHeader("side b")).toBe("SIDE_B");
+  });
+
+  it('returns REHAB for "rehab"', () => {
+    expect(detectSectionFromHeader("rehab")).toBe("REHAB");
+  });
+
+  it('returns MONITOR for "monitor"', () => {
+    expect(detectSectionFromHeader("monitor")).toBe("MONITOR");
+  });
+
+  it('returns MONITOR for "monitoring"', () => {
+    expect(detectSectionFromHeader("monitoring")).toBe("MONITOR");
+  });
+
+  // Trailing separators
+  it("handles trailing colon", () => {
+    expect(detectSectionFromHeader("צד א:")).toBe("SIDE_A");
+  });
+
+  it("handles trailing dash", () => {
+    expect(detectSectionFromHeader("צד ב -")).toBe("SIDE_B");
+  });
+
+  it("handles trailing em-dash", () => {
+    expect(detectSectionFromHeader("שיקום—")).toBe("REHAB");
+  });
+
+  // Rejection cases
+  it("rejects lines with digits (patient rows)", () => {
+    expect(detectSectionFromHeader("ניטור 3 כהן דני 55")).toBeNull();
+  });
+
+  it("rejects room-like text with numbers", () => {
+    expect(detectSectionFromHeader("101")).toBeNull();
+  });
+
+  it("returns null for unknown text", () => {
+    expect(detectSectionFromHeader("something random")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(detectSectionFromHeader("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only", () => {
+    expect(detectSectionFromHeader("   ")).toBeNull();
+  });
+});
+
+describe("detectSectionFromRoom", () => {
+  it('returns MONITOR for "ניטור1"', () => {
+    expect(detectSectionFromRoom("ניטור1")).toBe("MONITOR");
+  });
+
+  it('returns MONITOR for "ניטור-3"', () => {
+    expect(detectSectionFromRoom("ניטור-3")).toBe("MONITOR");
+  });
+
+  it('returns MONITOR for "מוניטור 2"', () => {
+    expect(detectSectionFromRoom("מוניטור 2")).toBe("MONITOR");
+  });
+
+  it('returns MONITOR for "monitor1"', () => {
+    expect(detectSectionFromRoom("monitor1")).toBe("MONITOR");
+  });
+
+  it("returns null for regular room numbers", () => {
+    expect(detectSectionFromRoom("101")).toBeNull();
+  });
+
+  it("returns null for room with slash format", () => {
+    expect(detectSectionFromRoom("55/1")).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(detectSectionFromRoom(null)).toBeNull();
+  });
+});

--- a/src/context/PatientsContext.tsx
+++ b/src/context/PatientsContext.tsx
@@ -30,7 +30,7 @@ interface PatientsState {
   shiftHistory: ShiftSnapshot[];
 }
 
-function normalizeTask(t: any): Task {
+export function normalizeTask(t: any): Task {
   return {
     ...t,
     done: !!t.done,
@@ -42,7 +42,7 @@ function normalizeTask(t: any): Task {
   } as Task;
 }
 
-function normalizePatient(p: any): PatientEntry {
+export function normalizePatient(p: any): PatientEntry {
   return {
     ...p,
     flags: Array.isArray(p.flags) ? p.flags : [],
@@ -96,7 +96,7 @@ const initialState: PatientsState = {
 // -----------------------------
 // Actions
 // -----------------------------
-type Action =
+export type Action =
   | { type: "IMPORT_TEXT"; text: string }
   | { type: "SET_SECTION"; section: Section }
   | { type: "TOGGLE_TASK"; patientId: string; taskId: string }
@@ -116,7 +116,7 @@ type Action =
   | { type: "CLEAR_ALL" }
   | { type: "TOGGLE_SHOW_TOMORROW" };
 
-function inferUrgencyFromText(text: string): Urgency {
+export function inferUrgencyFromText(text: string): Urgency {
   const t = text.trim();
   if (!t) return "routine";
   if (/(^|\b)(סטט|STAT|דחוף)(\b|!)/i.test(t)) return "stat";
@@ -141,7 +141,7 @@ function setTaskNoteInList(tasks: Task[], taskId: string, note: string | null): 
   return tasks.map((t) => (t.id === taskId ? { ...t, note } : t));
 }
 
-function reducer(state: PatientsState, action: Action): PatientsState {
+export function reducer(state: PatientsState, action: Action): PatientsState {
   switch (action.type) {
     case "IMPORT_TEXT": {
       const parsed = parsePatientList(action.text);


### PR DESCRIPTION
Rules engine: test all 29 medical rules (triggers, task counts, categories, group dedup, cross-cutting behavior). 111 tests.

Reducer: test all 17 action types (TOGGLE_TASK, ADD_TASK, ARCHIVE_SHIFT, REORDER_PATIENT, etc.), normalizeTask, normalizePatient, inferUrgencyFromText. 57 tests. Required exporting reducer and helpers from PatientsContext.

Parser: add edge cases for diagnosis extraction, age parsing, flag extraction (DNR/NPO/ISO/MRSA/FALL), task categorization, multi-patient parsing, empty inputs, confidence calculation, tomorrow notes, status extraction, monitor room inference. 36 tests.

mergeScan: add tests for fresh patient addition, empty scans, notes preservation, chained rescans, task note persistence, scannedAt updates. 13 tests.

patientKey: test strict/loose key building, normalization (whitespace, case, Hebrew), null handling, differentiation guarantees. 15 tests.

Section detection: test detectSectionFromHeader (Hebrew, English, separators, rejection cases) and detectSectionFromRoom. 28 tests.

CI/CD: add `npm run test` step to deploy.yml before build.

Also discovered: inferUrgencyFromText uses regex \b which doesn't work with Hebrew Unicode characters — documented as known limitation in tests.

https://claude.ai/code/session_016LQa5VAquTtn3wrkKvUoy7