### PR TITLE
Add scan diff detection and improve task/photo management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,33 @@ import { QRSync } from "./components/QRSync";
 import { QuickCaptureSheet } from "./components/QuickCaptureSheet";
 import { MorningReport } from "./components/MorningReport";
 import { requestNotificationPermission, syncReminders } from "./utils/taskReminders";
+import { formatScanDiffSummary } from "./engine/smartOCR";
+
+// ─── Scan Diff Banner ──────────────────────────────────────
+function ScanDiffBanner() {
+  const { lastScanDiff } = usePatientsState();
+  const dispatch = usePatientsDispatch();
+
+  if (!lastScanDiff) return null;
+  const summary = formatScanDiffSummary(lastScanDiff);
+  if (!summary) return null;
+
+  return (
+    <div
+      role="status"
+      className="w-full lg:max-w-6xl lg:mx-auto mx-0 px-3 py-2 bg-blue-50 dark:bg-blue-900/30 border-b border-blue-200 dark:border-blue-700 flex items-center justify-between gap-2 text-sm"
+    >
+      <span className="text-blue-800 dark:text-blue-300 font-medium">{summary}</span>
+      <button
+        onClick={() => dispatch({ type: "DISMISS_SCAN_DIFF" })}
+        className="text-blue-600 dark:text-blue-400 text-xs px-2 py-0.5 rounded border border-blue-300 dark:border-blue-600 active:opacity-70 shrink-0"
+        aria-label="סגור הודעת שינויים"
+      >
+        סגור
+      </button>
+    </div>
+  );
+}
 
 // ─── Shift Progress Bar ────────────────────────────────────
 function ShiftProgress() {
@@ -961,6 +988,7 @@ function AppInner() {
       </header>
 
       <ShiftProgress />
+      <ScanDiffBanner />
 
       <div className="w-full lg:max-w-6xl lg:mx-auto">
         <InputArea />

--- a/src/components/PatientCard.tsx
+++ b/src/components/PatientCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState, useCallback, useEffect } from "react";
 import type { PatientEntry, Task } from "../types";
 import { SECTIONS, SECTION_LABEL } from "../types";
 import { TaskItem } from "./TaskItem";
@@ -114,6 +114,13 @@ function HandoverNoteInline({ patient }: { patient: PatientEntry }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(patient.handoverNote ?? "");
   const note = patient.handoverNote;
+
+  // Sync draft when patient.handoverNote changes externally (e.g. after re-scan or cloud sync)
+  useEffect(() => {
+    if (!editing) {
+      setDraft(patient.handoverNote ?? "");
+    }
+  }, [patient.handoverNote, editing]);
 
   if (!editing && !note) {
     return (

--- a/src/components/PhotoAttachments.tsx
+++ b/src/components/PhotoAttachments.tsx
@@ -29,6 +29,8 @@ function compressImage(
   });
 }
 
+const MAX_PHOTOS = 5;
+
 export function PhotoAttachments({ patient }: { patient: PatientEntry }) {
   const dispatch = usePatientsDispatch();
   const [viewing, setViewing] = useState<PatientPhoto | null>(null);
@@ -38,6 +40,12 @@ export function PhotoAttachments({ patient }: { patient: PatientEntry }) {
   const handleCapture = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    if (photos.length >= MAX_PHOTOS) {
+      alert(`ניתן לצרף עד ${MAX_PHOTOS} תמונות לחולה. מחק תמונה קיימת לפני הוספת חדשה.`);
+      e.target.value = "";
+      return;
+    }
 
     const reader = new FileReader();
     reader.onload = async () => {
@@ -99,9 +107,11 @@ export function PhotoAttachments({ patient }: { patient: PatientEntry }) {
       {/* Add photo button */}
       <button
         onClick={() => inputRef.current?.click()}
-        className="text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-gray-600 dark:text-gray-400 active:bg-gray-100"
+        disabled={photos.length >= MAX_PHOTOS}
+        className="text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-gray-600 dark:text-gray-400 active:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+        aria-label={photos.length >= MAX_PHOTOS ? `הגעת למגבלת ${MAX_PHOTOS} תמונות` : "צלם או צרף תמונה"}
       >
-        📷 צלם / צרף תמונה
+        📷 צלם / צרף תמונה{photos.length >= MAX_PHOTOS ? ` (${MAX_PHOTOS}/${MAX_PHOTOS})` : photos.length > 0 ? ` (${photos.length}/${MAX_PHOTOS})` : ""}
       </button>
       <input
         ref={inputRef}

--- a/src/components/TaskDashboard.tsx
+++ b/src/components/TaskDashboard.tsx
@@ -167,7 +167,13 @@ export function TaskDashboard({ onClose }: { onClose: () => void }) {
 
         {tab === "sections" ? (
           <div className="flex-1 overflow-y-auto p-4">
-            <SectionDashboard patients={patients} onSelectSection={() => { onClose(); }} />
+            <SectionDashboard
+              patients={patients}
+              onSelectSection={(section: Section) => {
+                dispatch({ type: "SET_SECTION", section });
+                onClose();
+              }}
+            />
           </div>
         ) : tab === "route" ? (
           <div className="flex-1 overflow-y-auto p-3 space-y-3">

--- a/src/context/PatientsContext.tsx
+++ b/src/context/PatientsContext.tsx
@@ -13,6 +13,7 @@ import { applyRules } from "../engine/rules";
 import { generateId } from "../utils/id";
 import { safeGetItem, safeSetItem } from "../utils/storage";
 import { useToranotCloudSync, type ToranotCloudState, type SyncStatus, type ConflictData } from "../cloudSync";
+import { detectScanChanges, type ScanDiff } from "../engine/smartOCR";
 
 // -----------------------------
 // Constants
@@ -46,6 +47,7 @@ interface PatientsState {
   scanMode: boolean;
   events: WardEvent[];
   unassignedTasks: Task[];
+  lastScanDiff?: ScanDiff | null;
 }
 
 // Data loaded from localStorage or external sources may have missing/wrong-typed fields.
@@ -168,6 +170,7 @@ const initializer = (): PatientsState => ({
   scanMode: loadScanMode(),
   events: loadEvents(),
   unassignedTasks: loadUnassignedTasks(),
+  lastScanDiff: null,
 });
 
 // -----------------------------
@@ -206,7 +209,8 @@ export type Action =
   | { type: "ADD_UNASSIGNED_TASK"; text: string; urgency: Urgency }
   | { type: "ASSIGN_TASK_TO_PATIENT"; taskId: string; patientId: string }
   | { type: "TOGGLE_UNASSIGNED_TASK"; taskId: string }
-  | { type: "IMPORT_CLOUD_STATE"; state: ToranotCloudState };
+  | { type: "IMPORT_CLOUD_STATE"; state: ToranotCloudState }
+  | { type: "DISMISS_SCAN_DIFF" };
 
 export function inferUrgencyFromText(text: string): Urgency {
   const t = text.trim();
@@ -259,6 +263,10 @@ export function reducer(state: PatientsState, action: Action): PatientsState {
   switch (action.type) {
     case "IMPORT_TEXT": {
       const parsed = parsePatientList(action.text);
+      // Compute scan diff BEFORE merge so we compare old state vs fresh scan
+      const scanDiff = state.patients.length > 0
+        ? detectScanChanges(state.patients, parsed)
+        : null;
       const merged = mergeScan(state.patients, parsed);
       // Deduplicate beds: if two patients share room+section, keep the later one
       // (the scanned patient is more current than the stale one)
@@ -272,7 +280,13 @@ export function reducer(state: PatientsState, action: Action): PatientsState {
       const keepIndices = new Set(seen.values());
       // Also keep patients without rooms and patients that didn't collide
       const deduped = merged.filter((p, i) => !p.room || keepIndices.has(i));
-      return { ...state, patients: deduped };
+      // Only show diff banner if something actually changed
+      const hasDiff = scanDiff && (
+        scanDiff.newPatients.length > 0 ||
+        scanDiff.missingPatients.length > 0 ||
+        scanDiff.changedPatients.length > 0
+      );
+      return { ...state, patients: deduped, lastScanDiff: hasDiff ? scanDiff : null };
     }
     case "SET_SECTION":
       return { ...state, activeSection: action.section };
@@ -738,6 +752,9 @@ export function reducer(state: PatientsState, action: Action): PatientsState {
       };
     }
 
+    case "DISMISS_SCAN_DIFF":
+      return { ...state, lastScanDiff: null };
+
     default:
       return state;
   }
@@ -755,6 +772,7 @@ const PatientsStateContext = createContext<PatientsState>({
   scanMode: false,
   events: [],
   unassignedTasks: [],
+  lastScanDiff: null,
 });
 const PatientsDispatchContext = createContext<Dispatch<Action>>(() => {});
 

--- a/src/engine/smartOCR.ts
+++ b/src/engine/smartOCR.ts
@@ -101,11 +101,16 @@ export function detectScanChanges(
 }
 
 function normalizeKey(p: PatientEntry): string | null {
-  // Use name as primary key (most stable across room moves)
   const name = p.name?.trim();
   if (!name) return null;
   // Normalize Hebrew: remove niqqud, extra spaces
-  return name.replace(/[\u0591-\u05C7]/g, "").replace(/\s+/g, " ").trim();
+  const normalizedName = name.replace(/[\u0591-\u05C7]/g, "").replace(/\s+/g, " ").trim();
+  // Use room+name composite key to disambiguate common names in different rooms.
+  // Fall back to name-only when room is absent (e.g. newly admitted patient without bed).
+  if (p.room) {
+    return `${p.room}::${normalizedName}`;
+  }
+  return normalizedName;
 }
 
 /** Format diff as a short Hebrew summary */

--- a/src/utils/taskReminders.ts
+++ b/src/utils/taskReminders.ts
@@ -40,8 +40,17 @@ export function scheduleTaskReminder(
   const now = Date.now();
   const delay = reminderTime - now;
 
-  // Don't schedule if already past
-  if (delay < 0) return;
+  // If the due time is already past, fire immediately
+  if (dueTime < now) {
+    fireReminder(taskId, patientName, taskText, dueAt);
+    return;
+  }
+
+  // If reminder time is past but due time is still future, fire now
+  if (delay < 0) {
+    fireReminder(taskId, patientName, taskText, dueAt);
+    return;
+  }
 
   const timerId = setTimeout(() => {
     fireReminder(taskId, patientName, taskText, dueAt);


### PR DESCRIPTION
## Summary
This PR enhances the patient scanning workflow with visual feedback on changes, improves photo attachment limits, fixes task reminder timing, and refines patient matching logic during re-scans.

## Key Changes

- **Scan Diff Banner**: Added a dismissible banner that displays when patient data changes after a scan, showing a summary of new, missing, or modified patients. The banner uses the new `detectScanChanges()` function and `formatScanDiffSummary()` to provide user-friendly feedback.

- **Improved Patient Matching**: Enhanced the `normalizeKey()` function in smartOCR to use a composite `room::name` key instead of name-only matching. This disambiguates patients with common names in different rooms while gracefully falling back to name-only matching for patients without assigned beds.

- **Photo Attachment Limits**: Added a `MAX_PHOTOS` constant (5) with validation to prevent users from attaching more than 5 photos per patient. The button now shows the current count and becomes disabled at the limit with appropriate user feedback.

- **Task Reminder Timing Fix**: Modified `scheduleTaskReminder()` to fire reminders immediately if the due time has already passed, rather than silently skipping them. This ensures overdue tasks still trigger notifications.

- **Handover Note Sync**: Added `useEffect` hook to `HandoverNoteInline` to sync the draft state when `patient.handoverNote` changes externally (e.g., after re-scan or cloud sync), preventing stale edits.

- **Section Dashboard Navigation**: Fixed `TaskDashboard` to properly dispatch `SET_SECTION` action when selecting a section, ensuring the active section updates before closing the dashboard.

## Implementation Details

- The `ScanDiffBanner` component is rendered in the main app layout below the shift progress bar
- Scan diff detection only triggers the banner if actual changes are detected (new, missing, or changed patients)
- The banner includes Hebrew localization ("סגור" for close button)
- Photo limit validation includes both alert messaging and UI state management
- Task reminder improvements handle edge cases where reminders should fire immediately

https://claude.ai/code/session_01LDC1ZQBpdg71GnQJQRdt2r