### PR TITLE
fix(test): mergeScan scannedAt test wrong + flaky

### DIFF
--- a/src/__tests__/mergeScan.test.ts
+++ b/src/__tests__/mergeScan.test.ts
@@ -200,14 +200,19 @@ describe("mergeScan", () => {
     expect((mergedTask as any).note).toBe("BS 250ml");
   });
 
-  it("updates scannedAt timestamp on rescan", () => {
+  it("preserves original scannedAt across rescans (so isNewThisShift doesn't reset)", () => {
+    const originalTime = "2026-01-01T10:00:00.000Z";
     const first = parsePatientList(SCAN_TEXT);
+    first[0].scannedAt = originalTime;
 
     const second = parsePatientList(SCAN_TEXT);
+    second[0].scannedAt = new Date(Date.now() + 60000).toISOString(); // later timestamp
+
     const merged = mergeScan(first, second);
 
-    // The merged patient should have the new scannedAt
-    expect(merged[0].scannedAt).toBe(second[0].scannedAt);
+    // mergeScan intentionally preserves oldP.scannedAt so re-imports
+    // don't reset the "new this shift" detection for existing patients.
+    expect(merged[0].scannedAt).toBe(originalTime);
   });
 
   // ─── Order preservation tests ───


### PR DESCRIPTION
## Problem
The `updates scannedAt timestamp on rescan` test had two bugs:

**1. Wrong assertion** — `mergeScan` intentionally preserves `oldP.scannedAt` so `isNewThisShift` detection does not reset on every re-import (see comment in `mergeScan.ts` line 46). The test asserted the opposite.

**2. Flaky timing** — The test called `parsePatientList()` twice in quick succession; each call uses `new Date()` internally. On a loaded CI runner the two timestamps can differ by 1ms → `toBe` equality fails intermittently.

## Fix
- Renamed test to describe actual behaviour: `preserves original scannedAt across rescans`
- Uses a fixed `originalTime` constant as the baseline, so no timing dependency

## Tests
636/636 passing ✅