### PR TITLE
fix: blank page — add missing addCOIHeaders in SW, create sw-nuke.js, set Node 22

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   publish = "dist"
   command = "npm run build"
 
+[build.environment]
+  NODE_VERSION = "22"
+
 [functions]
   directory = "netlify/functions"
   node_bundler = "esbuild"

--- a/public/sw-nuke.js
+++ b/public/sw-nuke.js
@@ -1,0 +1,42 @@
+/**
+ * sw-nuke.js — Emergency service worker unregister.
+ * Loaded synchronously in index.html BEFORE the app bundle.
+ * If ?nuke-sw is in the URL, unregister all SWs and purge all caches,
+ * then reload cleanly. This is the escape hatch when a broken SW
+ * traps users in a blank-page loop.
+ */
+(function () {
+  if (
+    typeof navigator === "undefined" ||
+    !("serviceWorker" in navigator) ||
+    !window.location.search.includes("nuke-sw")
+  )
+    return;
+
+  navigator.serviceWorker
+    .getRegistrations()
+    .then(function (registrations) {
+      var tasks = registrations.map(function (r) {
+        return r.unregister();
+      });
+      return Promise.all(tasks);
+    })
+    .then(function () {
+      return caches.keys().then(function (names) {
+        return Promise.all(
+          names.map(function (n) {
+            return caches.delete(n);
+          })
+        );
+      });
+    })
+    .then(function () {
+      // Strip ?nuke-sw from URL so it doesn't loop
+      var url = new URL(window.location.href);
+      url.searchParams.delete("nuke-sw");
+      window.location.replace(url.toString());
+    })
+    .catch(function (err) {
+      console.error("[sw-nuke] Failed:", err);
+    });
+})();

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * Cross-Origin Isolation headers for SharedArrayBuffer (Tesseract.js).
  */
 
-const CACHE_VERSION = 1772619848112; // force-update 2026-03-04 emergency cache purge
+const CACHE_VERSION = 1773360000000; // force-update 2026-03-10 fix addCOIHeaders + blank page
 const CACHE_NAME = `toranot-v${CACHE_VERSION}`;
 
 /** @type {Map<string, ReturnType<typeof setTimeout>>} */
@@ -54,6 +54,22 @@ self.addEventListener("activate", (event) => {
     }),
   );
 });
+
+// ── Cross-Origin Isolation headers ──
+// Needed for SharedArrayBuffer (Tesseract.js OCR). Clones the response
+// and adds COOP/COEP headers. Falls through gracefully for opaque responses.
+function addCOIHeaders(response) {
+  // Can't modify opaque or error responses
+  if (response.type === "opaque" || response.type === "error") return response;
+  const headers = new Headers(response.headers);
+  headers.set("Cross-Origin-Embedder-Policy", "credentialless");
+  headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
 
 // ── Fetch ──
 self.addEventListener("fetch", (event) => {


### PR DESCRIPTION
Three issues causing blank page on Netlify:

1. sw.js called addCOIHeaders() on every fetch but the function was never
   defined — ReferenceError crashed every SW fetch handler, trapping users
   on stale cached pages.

2. sw-nuke.js referenced in index.html but file never existed — the
   emergency SW unregister escape hatch was non-functional. Now created
   in public/ (append ?nuke-sw to URL to trigger).

3. No NODE_VERSION set for Netlify — package.json requires Node ≥22 but
   Netlify defaults to 18. Build likely failed silently. Added
   NODE_VERSION=22 in netlify.toml [build.environment].

Also bumped CACHE_VERSION to force SW update for existing users.

https://claude.ai/code/session_015A9NspwhoYinFN9G7uD1Pm