### PR TITLE
fix: add BED_CONFLICT to WardEvent type union (fixes TS2322)

### DIFF
--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -503,7 +503,7 @@ function innerReducer(state: PatientsState, action: Action): PatientsState {
         const occupant = state.patients.find((p) => p.id === occupantId);
         const event: WardEvent = {
           id: generateId("ev-"),
-          type: "BED_CONFLICT" as WardEvent["type"],
+          type: "BED_CONFLICT",
           at: new Date().toISOString(),
           patientId: action.patientId,
           patientName: editTarget.name,
@@ -662,7 +662,7 @@ function innerReducer(state: PatientsState, action: Action): PatientsState {
         const moveOccupant = state.patients.find((p) => p.id === moveOccupantId);
         const conflictEvent: WardEvent = {
           id: generateId("ev-"),
-          type: "BED_CONFLICT" as WardEvent["type"],
+          type: "BED_CONFLICT",
           at: new Date().toISOString(),
           patientId: action.patientId,
           patientName: patient.name,

--- a/src/types/patient.ts
+++ b/src/types/patient.ts
@@ -288,4 +288,5 @@ export type WardEvent =
   | { id: string; type: "ADMISSION"; at: string; patientId: string; patientName: string | null; room: string | null }
   | { id: string; type: "MOVE"; at: string; patientId: string; patientName: string | null; from: string | null; to: string }
   | { id: string; type: "TASK_CREATED"; at: string; patientId?: string; patientName?: string | null; text: string; urgency: string }
-  | { id: string; type: "TASK_COMPLETED"; at: string; patientId: string; taskId: string; text: string };
+  | { id: string; type: "TASK_COMPLETED"; at: string; patientId: string; taskId: string; text: string }
+  | { id: string; type: "BED_CONFLICT"; at: string; patientId: string; patientName: string | null; text: string };


### PR DESCRIPTION
The previous commit introduced BED_CONFLICT events but forgot to add the type to the WardEvent discriminated union in types/patient.ts.

https://claude.ai/code/session_01QXFN6o14VxBiw88VMejLPo