### PR TITLE
Fix dismissed task filtering and reduce bundle size to <140KB

### DIFF
--- a/.claude/commands/toranot-audit-fix-deploy.md
+++ b/.claude/commands/toranot-audit-fix-deploy.md
@@ -10,7 +10,7 @@ Repo: github.com/Eiasash/Toranot
 Live: https://toranot.netlify.app
 Netlify site ID: 85d12386-b960-4f65-bee8-80e210ecd683
 Stack: React 19 + TypeScript + Tailwind CSS 4 + Zustand 5 + Vite 7
-Tests: 1588 tests, 46 files
+Tests: 1640 tests, 47 files
 Bundle target: <140KB
 
 ---
@@ -18,7 +18,7 @@ Bundle target: <140KB
 ## MANDATORY WORKFLOW — AFTER EVERY CHANGE
 ```
 1. npx tsc --noEmit                    — zero TypeScript errors
-2. npx vitest run                      — ALL 1588 tests must pass, zero failures
+2. npx vitest run                      — ALL 1640 tests must pass, zero failures
 3. npx vite build                      — must succeed, bundle must be <140KB
 4. Update README.md                    — Recent Changes section
 5. git add -A && git commit -m "..."   — see push procedure
@@ -138,7 +138,7 @@ npx vite build 2>&1 | grep -E "dist/|kB|KB"
 ### E. Test suite
 ```bash
 npx vitest run 2>&1 | tail -20
-# Must show: 1588 passed, 0 failed
+# Must show: 1640 passed, 0 failed
 # If count changed — update SKILL.md test count
 ```
 
@@ -439,7 +439,7 @@ jobs:
 ## PHASE 5 — SKILL FILE UPDATE
 
 After all changes committed and deployed, update `SKILL.md` (toranot-dev):
-- Update test count if changed (currently 1588 / 46 files)
+- Update test count if changed (currently 1640 / 47 files)
 - Update bundle size if changed (currently ~138KB)
 - Add any new gotchas discovered
 - Add new components to §1 repo structure
@@ -463,4 +463,4 @@ Then run `/toranot-update-skill` to verify self-consistency.
 - Never filter planNotes/tomorrowNotes into trigger matching
 - Never count dismissed tasks in aggregations
 - Never store GitHub PAT — remove from remote URL immediately after push
-- Test count must be verified after every change — 1588 is the baseline
+- Test count must be verified after every change — 1640 is the baseline

--- a/.github/workflows/toranot-weekly-audit.yml
+++ b/.github/workflows/toranot-weekly-audit.yml
@@ -1,0 +1,37 @@
+name: Toranot Weekly Audit
+on:
+  schedule:
+    - cron: '0 5 * * 1'  # Monday 5am UTC (7am Jerusalem)
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript check
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        run: npx vitest run
+
+      - name: Build and check bundle size
+        run: |
+          BUILD_OUT=$(npx vite build 2>&1)
+          echo "$BUILD_OUT"
+          SIZE=$(echo "$BUILD_OUT" | grep "dist/assets/index-" | grep "\.js " | grep -oP '[\d.]+\s*kB' | head -1 | grep -oP '[\d.]+')
+          echo "Bundle size: ${SIZE} kB"
+          if [ "$(echo "$SIZE > 140" | bc -l)" = "1" ]; then
+            echo "::error::Bundle size ${SIZE} kB exceeds 140 kB limit"
+            exit 1
+          fi

--- a/TORANOT_IMPROVEMENTS.md
+++ b/TORANOT_IMPROVEMENTS.md
@@ -1,0 +1,54 @@
+# Toranot Auto-Generated Improvement Proposals
+Generated: 2026-03-20
+Audit session: claude/toranot-audit-fix-deploy-UcE0i
+
+## Audit Summary
+- TypeScript: CLEAN (0 errors)
+- Tests: 1640 passed / 47 files (up from 1588 / 46)
+- Bundle: 138.72 kB (target <140 kB) — reduced from 143.44 kB
+- Rules: 57 groups, all unique, comfort care present
+- Drug safety: All 4 exports present (checkDrugInteractions, checkRenalDoseWarnings, checkBeersCriteria, checkAllergyConflicts)
+
+## Issues Fixed This Session
+
+### 1. Dismissed task filter gaps (Clinical)
+- `AIClinicalReasoning.tsx`: Open/done task aggregations now exclude `dismissed` tasks
+- `ParsePreview.tsx`: Total task count, stat count, and per-patient task list now filter dismissed
+- Root cause: generatedTasks were spread without `.filter(t => !t.dismissed)`, inflating counts and including suppressed tasks in AI reasoning context
+
+### 2. Bundle size over 140 kB target
+- `index.js` was 143.44 kB due to `DebugConsole.tsx` being pulled into main chunk
+- Extracted debug interceptors into `src/utils/debugLog.ts` (lightweight, no React dependency)
+- `main.tsx` now imports from `utils/debugLog` instead of `components/DebugConsole`
+- DebugConsole remains lazy-loaded, saving ~4.7 kB from main chunk
+- Result: 138.72 kB (under target)
+
+### 3. Infrastructure additions
+- Added `netlify/functions/toranot-keepalive.js` — pings Supabase every 5 days to prevent free-tier hibernation
+- Added `.github/workflows/toranot-weekly-audit.yml` — Monday 7am Jerusalem automated audit (typecheck + tests + bundle guard)
+- Updated `netlify.toml` with keepalive schedule
+
+## Clinical Coverage Gaps
+*Requires Supabase query against live patient data — see Phase 4A of audit skill.*
+*No patient data available in this environment for diagnosis-level analysis.*
+
+## Over-Triggering Rules
+*Requires live dismissed-task analysis from Supabase — see Phase 4B of audit skill.*
+
+## Drug Safety Gaps
+*Pending detailed analysis — agent running.*
+
+## Bundle Size Trend
+| Date | index.js | Status |
+|------|----------|--------|
+| 2026-03-20 (before) | 143.44 kB | OVER |
+| 2026-03-20 (after) | 138.72 kB | OK |
+
+## Proposed Next Session
+1. **Dynamic import reminderScheduler in App.tsx** — still causes a Vite warning about mixed static/dynamic imports; could save another ~2-3 kB from main chunk
+2. **Room simulation test expansion** — currently only 2 scenarios vs target of ≥104; add comprehensive room format test suite
+3. **Scanner.tsx room normalization** — Scanner delegates to parser (by design), but adding explicit room normalization in Scanner's `normalizeAndGroupBySection` would catch OCR formatting issues earlier
+4. **Component test coverage** — 41 components with 0 tests; prioritize PatientCard, PatientList, HandoffSheet
+5. **Supabase clinical analysis** — run Phase 4A/4B queries against live data to find diagnosis coverage gaps and over-triggering rules
+
+*All clinical rule additions require human review before implementation — patient safety constraint.*

--- a/TORANOT_IMPROVEMENTS.md
+++ b/TORANOT_IMPROVEMENTS.md
@@ -8,6 +8,9 @@ Audit session: claude/toranot-audit-fix-deploy-UcE0i
 - Bundle: 138.72 kB (target <140 kB) — reduced from 143.44 kB
 - Rules: 57 groups, all unique, comfort care present
 - Drug safety: All 4 exports present (checkDrugInteractions, checkRenalDoseWarnings, checkBeersCriteria, checkAllergyConflicts)
+- Drug interactions: 38 interactions across 6 severity categories
+- Beers Criteria 2023: 15 alert rules for ≥65yo patients
+- Renal dosing: 24 antibiotics covered (all empiric protocols)
 
 ## Issues Fixed This Session
 
@@ -29,14 +32,52 @@ Audit session: claude/toranot-audit-fix-deploy-UcE0i
 - Updated `netlify.toml` with keepalive schedule
 
 ## Clinical Coverage Gaps
-*Requires Supabase query against live patient data — see Phase 4A of audit skill.*
-*No patient data available in this environment for diagnosis-level analysis.*
+
+**Geriatric conditions not covered by any rule (by design — on-call acute focus):**
+
+| Condition | Why Not Covered | Potential Rule? |
+|-----------|----------------|-----------------|
+| New-onset atrial fibrillation | No RVR management rule | **YES** — rate control (Metoprolol IV/PO), anticoag decision, ECG |
+| Opioid-related constipation | No bowel protocol | **YES** — Senna + Docusate prophylaxis when opioid detected |
+| Bradycardia / AV block | Not covered | **MAYBE** — atropine if symptomatic, pacing if high-grade |
+| Hypothermia | Not covered | Low priority — rare in geriatric ward |
+| Pain management (Paracetamol) | No standing orders | Low priority — nursing-driven |
+| Chronic HTN management | Only emergency covered | No — chronic management is daytime work |
+| Dementia baseline | Only in delirium/Beers context | No — admission workup, not on-call |
+| Mild dehydration | Only under specific conditions | No — covered by existing rules (sepsis, AKI, etc.) |
+
+**Recommended new rules (require human approval):**
+1. `af_rvr` — New-onset AF with rapid ventricular response: rate control, ECG, anticoag assessment
+2. `opioid_bowel` — Bowel protocol prophylaxis when opioid medications detected in patient data
+
+*Never auto-add clinical rules — patient safety constraint.*
 
 ## Over-Triggering Rules
-*Requires live dismissed-task analysis from Supabase — see Phase 4B of audit skill.*
+*Requires live dismissed-task analysis from Supabase — run Phase 4B queries against production data.*
 
-## Drug Safety Gaps
-*Pending detailed analysis — agent running.*
+Known design overlaps (handled by deduplication):
+- Fever + Sepsis both generate "blood cultures x2" — caught by `applyRules()` dedup (line 1066-1072)
+- Delirium + specific drugs (e.g., haloperidol) — intentional overlap; generic workup vs. drug-specific monitoring
+
+## Drug Safety Coverage
+
+### Drug Interactions (38 total)
+| Category | Count | Key Examples |
+|----------|-------|-------------|
+| QT Prolongation | 8 | Amiodarone+Cipro, Haloperidol+Ondansetron |
+| Bleeding Risk | 9 | Warfarin+NSAID (critical), DOAC+NSAID (critical) |
+| Hyperkalemia | 6 | ACEi+Spironolactone, TMP-SMX+Spironolactone (critical) |
+| Serotonin Syndrome | 4 | Linezolid+SSRI (critical), SSRI+Tramadol |
+| Respiratory Depression | 1 | Benzodiazepine+Opioid (critical) |
+| Nephrotoxicity | 8 | NSAID+ACEi/ARB Triple Whammy (critical) |
+
+### Beers Criteria 2023 (15 rules)
+Full coverage of high-risk geriatric medications: Zolpidem, benzodiazepines, tramadol, TCAs, first-gen antihistamines, first-gen antipsychotics, sulfonylureas, NSAIDs ≥75yo, muscle relaxants, digoxin, PPIs >8wk, metoclopramide, anticholinergic burden.
+
+### Renal Dosing (24 antibiotics)
+All empiric DAG antibiotics covered. Extended-infusion notes for Pip-Tazo and Meropenem.
+
+**No gaps identified in drug safety coverage.**
 
 ## Bundle Size Trend
 | Date | index.js | Status |
@@ -45,10 +86,10 @@ Audit session: claude/toranot-audit-fix-deploy-UcE0i
 | 2026-03-20 (after) | 138.72 kB | OK |
 
 ## Proposed Next Session
-1. **Dynamic import reminderScheduler in App.tsx** — still causes a Vite warning about mixed static/dynamic imports; could save another ~2-3 kB from main chunk
-2. **Room simulation test expansion** — currently only 2 scenarios vs target of ≥104; add comprehensive room format test suite
-3. **Scanner.tsx room normalization** — Scanner delegates to parser (by design), but adding explicit room normalization in Scanner's `normalizeAndGroupBySection` would catch OCR formatting issues earlier
-4. **Component test coverage** — 41 components with 0 tests; prioritize PatientCard, PatientList, HandoffSheet
-5. **Supabase clinical analysis** — run Phase 4A/4B queries against live data to find diagnosis coverage gaps and over-triggering rules
+1. **New rule: `af_rvr`** — Atrial fibrillation with rapid ventricular response (rate control, ECG, anticoag). Requires human review.
+2. **New rule: `opioid_bowel`** — Bowel protocol prophylaxis when opioids detected. Requires human review.
+3. **Dynamic import reminderScheduler in App.tsx** — still causes a Vite warning about mixed static/dynamic imports; could save another ~2-3 kB from main chunk
+4. **Room simulation test expansion** — currently only 2 scenarios vs target of ≥104; add comprehensive room format test suite
+5. **Component test coverage** — 41 components with 0 tests; prioritize PatientCard, PatientList, HandoffSheet
 
 *All clinical rule additions require human review before implementation — patient safety constraint.*

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,9 @@
   directory = "netlify/functions"
   node_bundler = "esbuild"
 
+[functions."toranot-keepalive"]
+  schedule = "0 6 */5 * *"
+
 [functions."claude"]
   included_files = []
 

--- a/netlify/functions/toranot-keepalive.js
+++ b/netlify/functions/toranot-keepalive.js
@@ -1,0 +1,29 @@
+// Scheduled function: pings Supabase every 5 days to prevent free-tier hibernation.
+// [functions.toranot-keepalive]
+// schedule = "0 6 */5 * *"
+import { createClient } from '@supabase/supabase-js';
+
+export async function handler() {
+  const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    return { statusCode: 500, body: "Missing Supabase credentials" };
+  }
+
+  const supabase = createClient(url, key);
+
+  const { error } = await supabase.from('toranot_config')
+    .upsert({
+      key: 'keepalive_last',
+      value: JSON.stringify(new Date().toISOString()),
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'key' });
+
+  if (error) {
+    console.error("Keepalive failed:", error.message);
+    return { statusCode: 500, body: error.message };
+  }
+
+  return { statusCode: 200, body: "ok" };
+}

--- a/src/components/AIClinicalReasoning.tsx
+++ b/src/components/AIClinicalReasoning.tsx
@@ -146,14 +146,14 @@ function buildPatientContext(patient: PatientEntry): string {
   }
 
   const openTasks = [...patient.tasks, ...patient.generatedTasks]
-    .filter((t) => !t.done)
+    .filter((t) => !t.done && !t.dismissed)
     .map((t) => `[${t.urgency}] ${t.text}`);
   if (openTasks.length > 0) {
     parts.push(`משימות פתוחות:\n${openTasks.join("\n")}`);
   }
 
   const doneTasks = [...patient.tasks, ...patient.generatedTasks]
-    .filter((t) => t.done)
+    .filter((t) => t.done && !t.dismissed)
     .map((t) => t.text);
   if (doneTasks.length > 0) {
     parts.push(`בוצע: ${doneTasks.join(", ")}`);

--- a/src/components/DebugConsole.tsx
+++ b/src/components/DebugConsole.tsx
@@ -1,63 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { ERROR_LOG, type LogEntry } from "../utils/debugLog";
 
-interface LogEntry {
-  level: "log" | "warn" | "error" | "info";
-  timestamp: string;
-  args: string;
-}
-
-// Global error log buffer — captures console output + window errors
-const ERROR_LOG: LogEntry[] = [];
-const MAX_LOG_ENTRIES = 200;
-
-// Intercept console methods once at module load
-const origConsole = {
-  log: console.log.bind(console),
-  warn: console.warn.bind(console),
-  error: console.error.bind(console),
-  info: console.info.bind(console),
-};
-
-function serialize(args: unknown[]): string {
-  return args
-    .map((a) => {
-      if (a instanceof Error) return `${a.name}: ${a.message}\n${a.stack ?? ""}`;
-      if (typeof a === "object") {
-        try { return JSON.stringify(a, null, 2); } catch { return String(a); }
-      }
-      return String(a);
-    })
-    .join(" ");
-}
-
-function pushEntry(level: LogEntry["level"], args: unknown[]) {
-  const entry: LogEntry = {
-    level,
-    timestamp: new Date().toISOString(),
-    args: serialize(args),
-  };
-  ERROR_LOG.push(entry);
-  if (ERROR_LOG.length > MAX_LOG_ENTRIES) ERROR_LOG.splice(0, ERROR_LOG.length - MAX_LOG_ENTRIES);
-}
-
-// Patch console globally (idempotent — only once)
-let _patched = false;
-export function installDebugInterceptors() {
-  if (_patched) return;
-  _patched = true;
-
-  console.log = (...args: unknown[]) => { pushEntry("log", args); origConsole.log(...args); };
-  console.warn = (...args: unknown[]) => { pushEntry("warn", args); origConsole.warn(...args); };
-  console.error = (...args: unknown[]) => { pushEntry("error", args); origConsole.error(...args); };
-  console.info = (...args: unknown[]) => { pushEntry("info", args); origConsole.info(...args); };
-
-  window.addEventListener("error", (e) => {
-    pushEntry("error", [`[Uncaught] ${e.message}`, e.filename ? `at ${e.filename}:${e.lineno}:${e.colno}` : ""]);
-  });
-  window.addEventListener("unhandledrejection", (e) => {
-    pushEntry("error", [`[Unhandled Promise] ${e.reason}`]);
-  });
-}
+// Re-export for backward compatibility
+export { installDebugInterceptors } from "../utils/debugLog";
 
 const LEVEL_STYLE: Record<LogEntry["level"], string> = {
   error: "text-red-400 bg-red-900/20",

--- a/src/components/ParsePreview.tsx
+++ b/src/components/ParsePreview.tsx
@@ -147,13 +147,13 @@ export function ParsePreview({ patients: initialPatients, onConfirm, onCancel }:
 
   const sections = groupBySection(patients);
   const totalTasks = patients.reduce(
-    (sum, p) => sum + p.tasks.length + p.generatedTasks.length,
+    (sum, p) => sum + p.tasks.length + p.generatedTasks.filter(t => !t.dismissed).length,
     0,
   );
   const statCount = patients.reduce(
     (sum, p) =>
       sum +
-      [...p.tasks, ...p.generatedTasks].filter(
+      [...p.tasks, ...p.generatedTasks.filter(t => !t.dismissed)].filter(
         (t) => !t.done && t.urgency === "stat",
       ).length,
     0,
@@ -214,7 +214,7 @@ export function ParsePreview({ patients: initialPatients, onConfirm, onCancel }:
             </div>
 
             {pts.map((p) => {
-              const allTasks = [...p.tasks, ...p.generatedTasks];
+              const allTasks = [...p.tasks, ...p.generatedTasks.filter(t => !t.dismissed)];
               const pending = allTasks.filter((t) => !t.done);
               const statTasks = pending.filter((t) => t.urgency === "stat");
               const urgentTasks = pending.filter((t) => t.urgency === "urgent");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./index.css";
-import { installDebugInterceptors } from "./components/DebugConsole";
+import { installDebugInterceptors } from "./utils/debugLog";
 
 // Install debug log interceptors before anything else
 installDebugInterceptors();

--- a/src/utils/debugLog.ts
+++ b/src/utils/debugLog.ts
@@ -1,0 +1,61 @@
+/**
+ * Global error-log buffer + console interceptors.
+ * Extracted from DebugConsole so main.tsx can install interceptors
+ * without pulling the full React component into the main chunk.
+ */
+
+export interface LogEntry {
+  level: "log" | "warn" | "error" | "info";
+  timestamp: string;
+  args: string;
+}
+
+export const ERROR_LOG: LogEntry[] = [];
+const MAX_LOG_ENTRIES = 200;
+
+const origConsole = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+function serialize(args: unknown[]): string {
+  return args
+    .map((a) => {
+      if (a instanceof Error) return `${a.name}: ${a.message}\n${a.stack ?? ""}`;
+      if (typeof a === "object") {
+        try { return JSON.stringify(a, null, 2); } catch { return String(a); }
+      }
+      return String(a);
+    })
+    .join(" ");
+}
+
+function pushEntry(level: LogEntry["level"], args: unknown[]) {
+  const entry: LogEntry = {
+    level,
+    timestamp: new Date().toISOString(),
+    args: serialize(args),
+  };
+  ERROR_LOG.push(entry);
+  if (ERROR_LOG.length > MAX_LOG_ENTRIES) ERROR_LOG.splice(0, ERROR_LOG.length - MAX_LOG_ENTRIES);
+}
+
+let _patched = false;
+export function installDebugInterceptors() {
+  if (_patched) return;
+  _patched = true;
+
+  console.log = (...args: unknown[]) => { pushEntry("log", args); origConsole.log(...args); };
+  console.warn = (...args: unknown[]) => { pushEntry("warn", args); origConsole.warn(...args); };
+  console.error = (...args: unknown[]) => { pushEntry("error", args); origConsole.error(...args); };
+  console.info = (...args: unknown[]) => { pushEntry("info", args); origConsole.info(...args); };
+
+  window.addEventListener("error", (e) => {
+    pushEntry("error", [`[Uncaught] ${e.message}`, e.filename ? `at ${e.filename}:${e.lineno}:${e.colno}` : ""]);
+  });
+  window.addEventListener("unhandledrejection", (e) => {
+    pushEntry("error", [`[Unhandled Promise] ${e.reason}`]);
+  });
+}


### PR DESCRIPTION
## Summary
This PR addresses two critical issues: (1) dismissed tasks were being incorrectly included in task counts and AI reasoning context, and (2) bundle size exceeded the 140KB target. Additionally, infrastructure improvements for production stability are included.

## Key Changes

### Clinical Fixes
- **AIClinicalReasoning.tsx**: Filter out dismissed tasks when building open/done task context for AI reasoning
- **ParsePreview.tsx**: Exclude dismissed tasks from total task count, stat count aggregations, and per-patient task lists

### Bundle Size Optimization
- **Extract debug interceptors**: Moved console interception logic from `DebugConsole.tsx` to new `src/utils/debugLog.ts` (no React dependency)
- **Lazy-load DebugConsole**: `main.tsx` now imports lightweight `debugLog` utilities instead of the full React component
- **Result**: Reduced bundle from 143.44 kB to 138.72 kB (under 140 kB target)

### Infrastructure
- **Netlify keepalive function** (`netlify/functions/toranot-keepalive.js`): Pings Supabase every 5 days to prevent free-tier hibernation
- **Weekly audit workflow** (`.github/workflows/toranot-weekly-audit.yml`): Automated Monday 7am Jerusalem checks for TypeScript errors, test failures, and bundle size violations
- **Updated netlify.toml**: Configured keepalive function schedule

### Documentation
- **TORANOT_IMPROVEMENTS.md**: Comprehensive audit report including test results (1640 passed / 47 files), drug safety coverage, clinical gaps analysis, and recommended next steps

## Implementation Details
- Dismissed task filtering uses consistent `.filter(t => !t.dismissed)` pattern across all aggregation points
- Debug interceptors remain idempotent (checked via `_patched` flag) to prevent double-patching
- `DebugConsole.tsx` re-exports `installDebugInterceptors` for backward compatibility
- Bundle optimization preserves all functionality while reducing main chunk size by ~4.7 kB

https://claude.ai/code/session_01AoW1xTn3ic8cP5ZVWaQRun