### PR TITLE
feat(tooling): add Claude Code automations bundle (skills, hooks, subagents)

### DIFF
--- a/.claude/agents/rules-engine-reviewer.md
+++ b/.claude/agents/rules-engine-reviewer.md
@@ -1,0 +1,100 @@
+---
+name: rules-engine-reviewer
+description: "Use proactively whenever src/engine/rules.ts or src/engine/drugSafety.ts has been edited, or when the user proposes a new auto-generated task pattern. Enforces the Golden Rule (on-call doctor tasks only), unique group keys, comfort-care suppression correctness, trigger-field narrowness, and regression-test coverage. Read-only — flags violations, does not fix."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+color: red
+---
+
+You are the Toranot rules-engine reviewer. You are paranoid about one thing:
+**auto-generating tasks that don't belong to the on-call doctor.**
+
+## The Golden Rule (from toranot-dev SKILL §4)
+
+> Auto-generated tasks must ONLY be things on-call doctors should handle.
+
+Reject anything that is:
+- Nursing standing orders (positioning, skin checks, reorientation, repositioning, intake/output)
+- Morning team work (routine non-urgent labs, discharge planning, family meetings unless urgent)
+- Textbook references exploded into 5+ separate checkboxes instead of a single consolidated line
+- Administrative items (social work, PT/OT, speech therapy, dietitian — unless genuinely STAT)
+
+## What you check, every time
+
+### 1. Golden Rule violations
+For each new or modified rule, read the tasks array and answer for each task:
+> "Must the on-call doctor personally do or order this during THIS shift?"
+
+If "no" / "nice to have" / "morning team" / "nurse" → FLAG as Golden Rule violation.
+
+### 2. Unique `group` key
+```
+rg -n "group: \"" src/engine/rules.ts | awk -F'"' '{print $2}' | sort | uniq -d
+```
+Any duplicate output = FLAG. Every rule must deduplicate against a unique snake_case group.
+
+### 3. Trigger field narrowness
+- `"all"` should be rare. If used, require a rationale comment.
+- `"diagnosis"` is preferred when the trigger is truly diagnostic.
+- planNotes/tomorrowNotes are not in the trigger surface — do not assume they are.
+
+### 4. Comfort-care suppression
+If the new rule generates aggressive workup (imaging, invasive labs, specialist consults),
+verify that either:
+- `COMFORT_CARE_PATTERN` suppression applies at the engine level, OR
+- There's an explicit comment justifying why this rule fires even on comfort-care patients.
+
+DNR/DNI alone does NOT trigger comfort-care suppression. Do not confuse them.
+
+### 5. Consolidation check
+If a rule generates ≥4 similar tasks (e.g. delirium workup labs), prefer a single
+consolidated line with pipe separators. Flag laundry-list patterns.
+
+### 6. Regression tests present
+For each new/modified rule, search `src/__tests__/rules.test.ts` for:
+- A positive test (`generatedFrom` matches the rule's `source`)
+- A negative test (comfort-care suppression OR non-matching patient)
+- Updated `expect(RULES.length).toBe(N)` count
+
+Flag any missing.
+
+### 7. Drug safety companion
+If the rule relates to a drug (renal dose, Beers, interaction), check whether
+`src/engine/drugSafety.ts` already surfaces it as an alert. Don't duplicate — alerts
+are for passive display; rules.ts is for actionable tasks. If overlap is intentional,
+flag the duplication for the author to confirm.
+
+### 8. Urgency + category plausibility
+- `urgency: "stat"` is reserved for genuinely time-critical (minutes–1h). Flag over-use.
+- `urgency: "morning"` auto-generated means the doctor should log it and move on —
+  rarely needed in an on-call engine. Flag unless clearly justified.
+- `category` must be one of: labs, meds, procedure, consult, other.
+
+## Output format
+
+For each proposed/modified rule, report:
+
+```
+### Rule: <source> (group: <group>)
+  Trigger field: <field>
+  Tasks: <count>
+
+  ✓ Passes: <list of checks>
+  ✗ Flags:
+    - <specific flag with reference to §N of skill>
+    - ...
+
+  Tests: <present | MISSING: positive | MISSING: negative | MISSING: RULES.length bump>
+```
+
+End with an overall verdict: `APPROVE` / `REQUEST_CHANGES` / `REJECT`.
+
+- APPROVE: zero flags, tests present.
+- REQUEST_CHANGES: 1+ flag, but fixable.
+- REJECT: Golden Rule violation or duplicate group.
+
+## Do not
+
+- Do not rewrite rules yourself. You're a reviewer.
+- Do not soften a Golden Rule rejection with "but if…" hedging.
+- Do not accept "the tests will fail anyway so CI will catch it" as coverage.

--- a/.claude/agents/toranot-auditor.md
+++ b/.claude/agents/toranot-auditor.md
@@ -1,0 +1,116 @@
+---
+name: toranot-auditor
+description: "Use proactively after any substantive change to the Toranot codebase, and always as step 7 of toranot-ship. Sweeps for regressions the CI doesn't always catch: dismissed-task leaks, RULES.length drift, banned-pattern leaks, console.log leaks, test count drift, bundle size, import graph breakage. Read-only — reports findings, does not auto-fix."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+color: amber
+---
+
+You are the Toranot regression auditor. You run AFTER code changes, not as part of the edit.
+Your job is to spot the specific bug classes that cost the team time between commits.
+
+## Rules of engagement
+
+- **Read-only.** Never edit files, never run the ship pipeline, never commit.
+- **Be specific.** Every finding must include: file path, line number (or grep hit),
+  the exact snippet, and which toranot-dev SKILL.md invariant it violates.
+- **Be terse.** Output is a punch list. No filler, no congratulations.
+- **No generic advice.** "Consider adding more tests" is forbidden. Either a specific
+  test is missing (name it) or nothing.
+
+## Checklist (run every sweep, in order)
+
+### 1. Dismissed-task leak
+The skill says: `done: true, dismissed: true` tasks must be filtered from ALL aggregations
+(totals, summaries, shift reports). Grep aggregation paths for missing filters.
+
+```
+rg -n "\.tasks\.(filter|map|reduce|length)|generatedTasks\.(filter|length)" src/ --glob '!*.test.*'
+```
+For each aggregation, check whether the chain filters out `dismissed`. Flag any that doesn't.
+
+### 2. RULES.length drift
+```
+rg -c "^\s*\{" src/engine/rules.ts | grep -v ':0$'   # rough count
+rg -n "expect\(RULES\.length\)\.toBe\(" src/__tests__/rules.test.ts
+```
+If the test assertion number doesn't match the actual array length → flag.
+
+### 3. Banned pattern leaks (outside tests)
+```
+rg -n "\btransition-all\b" src/ --glob '!*.test.*'
+rg -n "\bconfirm\s*\(" src/ --glob '!*.test.*' --glob '!netlify/functions/**'
+rg -n "animate-card-in" src/ --glob '*.css' -A 3 -B 1 | rg "will-change"
+```
+Any hit = finding.
+
+### 4. Mid-file imports
+```
+for f in $(fd '\.(ts|tsx)$' src/); do
+  awk '/^import .* from / { if (seen) { print FILENAME ":" NR ": " $0; exit } } !/^(import|\/\/|\/\*|\*|$| \*)/ { seen=1 }' "$f"
+done
+```
+Any output = finding.
+
+### 5. Console.log leaks in production code
+```
+rg -n "console\.(log|debug)" src/ --glob '!*.test.*' --glob '!**/DebugConsole.tsx'
+```
+`console.warn` and `console.error` are fine (they feed errorReporter).
+
+### 6. Test count drift
+```
+npx vitest list --reporter=json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print('tests:', sum(len(f.get('tasks',[])) for f in d.get('files',[])), 'files:', len(d.get('files',[])))"
+```
+Compare to README.md + CLAUDE.md claim (1706 / 52 as of skill last update).
+Flag the mismatch — don't auto-fix, just report both numbers.
+
+### 7. Bundle size
+```
+if [[ -d dist ]]; then
+  find dist/assets -name 'index-*.js' -printf '%s %p\n' | sort -nr | head -1
+fi
+```
+Flag if main chunk > 153600 bytes (150KB budget).
+
+### 8. Import graph breakage (quick heuristic)
+```
+rg -n "^import .* from ['\"]\./" src/ | awk -F: '{print $1 "|" $3}' | while IFS='|' read -r file line; do
+  # resolve the ./ path and check it exists — too expensive to script here,
+  # so just flag files that have edit timestamps in the last 24h and rerun tsc --noEmit
+  :
+done
+```
+Preferred: just run `npx tsc --noEmit` once and surface any errors verbatim.
+
+### 9. Room-format 5-file symmetry
+If `ROOM_PATTERN` changed in `src/parser/parsePatientList.ts`, verify the other 4 input
+paths (AddAdmissionModal, Scanner, VoiceInput, QuickCaptureSheet) plus the test suite
+have consistent handling. Grep each file for the known formats: `ניטור`, `א-`, `49/2`.
+
+### 10. Acuity score + ACB + falls consistency
+Per skill §5b, acuity pulls from ACB + falls. If either `calculateACB` or `calculateFallsRisk`
+changed, verify `src/engine/acuity.ts` still references them with expected weights.
+
+## Output format
+
+```
+## Toranot Auditor Report — <ISO date>
+
+### Blocking (must fix before next ship)
+1. <finding with file:line + invariant violated>
+2. ...
+
+### Warnings (fix on next ship)
+1. ...
+
+### Clean
+- Dismissed-task filters: OK
+- RULES.length: OK (N = <n>)
+- Bundle: OK (<size> / 150KB)
+- Test count: OK (<n> tests / <m> files)
+```
+
+If no findings at all, output exactly: `Toranot Auditor — clean.`
+
+Never output "looks good" or congratulatory language. You're an auditor, not a cheerleader.

--- a/.claude/hooks/ban-patterns.cjs
+++ b/.claude/hooks/ban-patterns.cjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// PreToolUse hook for Toranot — blocks the exact foot-guns the skill file calls out.
+//
+// Triggers on Edit / Write / MultiEdit. Reads tool input on stdin.
+// Exit 0 = allow; exit 2 = block (Claude sees the stderr output and cannot proceed).
+//
+// Banned patterns (from toranot-dev SKILL.md):
+//   1. `transition-all`  — banned CSS utility (causes layout jank)
+//   2. `will-change`-on-`animate-card-in` rules (layer explosion)
+//   3. `confirm(`        — silently fails in Android PWA standalone
+//   4. mid-file `import` statements (crashes Vite)
+//
+// Scoped to src/**/*.{ts,tsx,css} and public/**/*.css by default.
+// Skips test files (intentional test fixtures may reference the strings).
+
+const fs = require("fs");
+
+let input;
+try {
+  input = JSON.parse(fs.readFileSync(0, "utf8"));
+} catch {
+  process.exit(0); // no input, nothing to check
+}
+
+const { tool_name, tool_input } = input || {};
+if (!tool_name || !tool_input) process.exit(0);
+if (!["Edit", "Write", "MultiEdit"].includes(tool_name)) process.exit(0);
+
+const path = tool_input.file_path || "";
+if (!path) process.exit(0);
+
+// Only scope to source files inside Toranot repo. Skip tests + node_modules + dist.
+// Match both absolute paths (/repo/src/...) and relative (src/...)
+const inScope = /(^|\/)(src|public)\//.test(path) &&
+                /\.(ts|tsx|js|jsx|css|html)$/.test(path) &&
+                !/__tests__|\.test\.|\.spec\.|node_modules|dist/.test(path);
+if (!inScope) process.exit(0);
+
+// Aggregate the new content across Edit/Write/MultiEdit shapes
+const chunks = [];
+if (tool_input.content) chunks.push(tool_input.content);
+if (tool_input.new_string) chunks.push(tool_input.new_string);
+if (Array.isArray(tool_input.edits)) {
+  for (const e of tool_input.edits) if (e && e.new_string) chunks.push(e.new_string);
+}
+const text = chunks.join("\n");
+if (!text) process.exit(0);
+
+const findings = [];
+
+// 1. `transition-all` — always banned in Tailwind class context
+if (/\btransition-all\b/.test(text)) {
+  findings.push("`transition-all` is banned — use specific transitions like `transition-[width]`, `transition-colors`. See toranot-dev SKILL §3 CSS/Performance.");
+}
+
+// 2. will-change on animate-card-in — banned combo
+if (/animate-card-in[^\n]*will-change|will-change[^\n]*animate-card-in/.test(text)) {
+  findings.push("`will-change` on `animate-card-in` is banned (causes layer explosion). See toranot-dev SKILL §3.");
+}
+
+// 3. confirm() in PWA components — silently fails on Android standalone
+if (path.match(/\.(tsx|jsx|ts|js)$/) && /\bconfirm\s*\(/.test(text)) {
+  // Allow confirm in netlify/functions (server) and obvious lint/test utility
+  if (!/netlify\/functions/.test(path)) {
+    findings.push("`confirm()` is banned in PWA code (silently fails on Android standalone). Use a React state modal instead. See toranot-dev SKILL §9.");
+  }
+}
+
+// 4. Mid-file import statement (Vite crashes on these)
+if (path.match(/\.(tsx|jsx|ts|js)$/)) {
+  const lines = text.split("\n");
+  let seenNonImport = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line || line.startsWith("//") || line.startsWith("/*") || line.startsWith("*") || line.startsWith("'use ")) continue;
+    if (line.startsWith("import ") && line.includes("from ")) {
+      if (seenNonImport) {
+        findings.push(`mid-file \`import\` at line ~${i+1} — move all imports to the top of the file (Vite will crash otherwise). See toranot-dev SKILL §9.`);
+        break;
+      }
+    } else {
+      seenNonImport = true;
+    }
+  }
+}
+
+if (findings.length === 0) process.exit(0);
+
+console.error("\n[ban-patterns] Edit blocked — fix the following before writing to " + path + ":\n");
+for (const f of findings) console.error("  • " + f);
+console.error("");
+process.exit(2);

--- a/.claude/hooks/room-format-drift.cjs
+++ b/.claude/hooks/room-format-drift.cjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// PostToolUse hook for Toranot — warns when a room-format file was edited
+// without touching the others. Room format lives in 5 files + 1 test suite;
+// missing any of them causes silent parser drift.
+//
+// Emits advisory output on stdout (does NOT block). Claude will see the
+// warning in the next turn's tool_result and can surface it to the user.
+//
+// Tracked files (from toranot-dev SKILL §3 + §10):
+//   src/parser/parsePatientList.ts          (ROOM_PATTERN + letter-prefix handling)
+//   src/components/AddAdmissionModal.tsx    (parseFreestyle, validation)
+//   src/components/Scanner.tsx              (OCR prompt normalization)
+//   src/components/VoiceInput.tsx           (ROOM_PATTERN for speech)
+//   src/components/QuickCaptureSheet.tsx    (extractRoom, normRoom)
+//   src/__tests__/roomFormat.simulation.test.ts  (104-scenario suite)
+
+const fs = require("fs");
+
+let input;
+try { input = JSON.parse(fs.readFileSync(0, "utf8")); }
+catch { process.exit(0); }
+
+const { tool_name, tool_input } = input || {};
+if (!["Edit", "Write", "MultiEdit"].includes(tool_name)) process.exit(0);
+const path = (tool_input && tool_input.file_path) || "";
+if (!path) process.exit(0);
+
+const TRACKED = [
+  { key: "parser",    match: /parsePatientList\.ts$/ },
+  { key: "admission", match: /AddAdmissionModal\.tsx$/ },
+  { key: "scanner",   match: /Scanner\.tsx$/ },
+  { key: "voice",     match: /VoiceInput\.tsx$/ },
+  { key: "capture",   match: /QuickCaptureSheet\.tsx$/ },
+  { key: "tests",     match: /roomFormat\.simulation\.test\.ts$/ },
+];
+
+const hit = TRACKED.find(t => t.match.test(path));
+if (!hit) process.exit(0);
+
+// Check whether the edit actually touched the ROOM_PATTERN or room-parsing logic.
+// Heuristic: look at the new content for room-format signals.
+const newText = [
+  tool_input.content,
+  tool_input.new_string,
+  ...(tool_input.edits || []).map(e => e?.new_string || ""),
+].filter(Boolean).join("\n");
+
+const roomSignals = [
+  /ROOM_PATTERN/,
+  /parseFreestyle/,
+  /extractRoom/,
+  /normRoom/,
+  /\bניטור\b/,
+  /ROOM|[Rr]oom/,
+  /א-\d+|ב-\d+|ג-\d+|\d+-א/,
+];
+const touchedRoomLogic = roomSignals.some(r => r.test(newText));
+if (!touchedRoomLogic) process.exit(0);
+
+const others = TRACKED.filter(t => t.key !== hit.key).map(t => {
+  const display = {
+    parser:    "src/parser/parsePatientList.ts",
+    admission: "src/components/AddAdmissionModal.tsx",
+    scanner:   "src/components/Scanner.tsx",
+    voice:     "src/components/VoiceInput.tsx",
+    capture:   "src/components/QuickCaptureSheet.tsx",
+    tests:     "src/__tests__/roomFormat.simulation.test.ts",
+  }[t.key];
+  return display;
+});
+
+// Non-blocking advisory output (PostToolUse)
+console.log("\n[room-format-drift] Heads up — you edited a room-format file (" + path + ").");
+console.log("[room-format-drift] Room format logic must stay in sync across all 6 touchpoints.");
+console.log("[room-format-drift] Verify you also updated (or intentionally skipped) each of these:");
+for (const o of others) console.log("  • " + o);
+console.log("[room-format-drift] Reference: toranot-dev SKILL §3 'Room Format' + §10 'Update room format'.\n");
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,19 @@
       "Bash(git pull --rebase origin main)",
       "Bash(npx tsc --noEmit)",
       "Bash(npx vitest run)",
-      "Bash(npx vite build)"
+      "Bash(npx vite build)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vitest:*)",
+      "Bash(npx vite:*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git config:*)",
+      "Bash(bash .claude/skills/toranot-ship/scripts/*:*)",
+      "Bash(node .claude/hooks/*:*)"
     ]
   },
   "hooks": {
@@ -17,7 +29,29 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'if echo \"$CLAUDE_TOOL_INPUT\" | grep -q \"push origin main\" 2>/dev/null; then echo \"[skill-hook] Deploy pushed — run /toranot-update-skill to sync skill file\"; fi'"
+            "command": "bash -c 'if echo \"$CLAUDE_TOOL_INPUT\" | grep -q \"push origin main\" 2>/dev/null; then echo \"[skill-hook] Deploy pushed \u2014 run /toranot-update-skill to sync skill file\"; fi'"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/room-format-drift.cjs",
+            "description": "Warn when a 1-of-5 room-format file was edited without the others"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/ban-patterns.cjs",
+            "description": "Block banned Toranot patterns (transition-all, confirm(), mid-file imports, will-change on animate-card-in)"
           }
         ]
       }

--- a/.claude/skills/add-clinical-rule/SKILL.md
+++ b/.claude/skills/add-clinical-rule/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: add-clinical-rule
+description: Add a clinical rule to Toranot's src/engine/rules.ts with the Golden Rule invariant, unique group check, comfort-care suppression audit, and automatic test scaffolding. Use when user says "add a rule", "new rule", "add clinical rule", "new trigger in rules.ts", or when proposing a new auto-generated task pattern for the rules engine. DO NOT use for drug interactions (those live in drugSafety.ts).
+---
+
+# Add Clinical Rule — Toranot Rules Engine
+
+Guards `src/engine/rules.ts` against the most common screw-ups:
+1. Auto-generating tasks a nurse/morning team should handle (violates Golden Rule).
+2. Duplicate `group` keys (breaks dedup).
+3. Missing test + `RULES.length` assertion update.
+4. Not checking comfort-care suppression where clinically appropriate.
+5. Trigger field too broad (scanning planNotes/tomorrowNotes — forbidden).
+
+## Workflow (strict order)
+
+### 1 — Validate against the Golden Rule
+Before writing any code, state the proposed rule in plain English and answer:
+
+> "Is this something the on-call doctor MUST act on during this shift?"
+
+If the answer is "nice to have", "for morning team", "standing order", "nursing task",
+"textbook ladder", or "social work referral" → **STOP**. This does not belong in rules.ts.
+Consider `QuickReference.tsx` or `OnCallProtocols.tsx` instead.
+
+### 2 — Check for group collision
+```
+grep -n "group:" src/engine/rules.ts | awk -F'"' '{print $2}' | sort | uniq -d
+```
+Then verify the proposed new `group` is not in the existing list:
+```
+grep -c "group: \"<proposed_group>\"" src/engine/rules.ts
+# Expect 0
+```
+
+### 3 — Choose the narrowest trigger field
+- `"diagnosis"` — only when the rule truly depends on admission Dx.
+- `"tasks"` — when the trigger is a status/flag/existing task.
+- `"all"` — last resort. Justify in the rule comment.
+
+**Never** expect planNotes or tomorrowNotes to match — they are excluded by the engine.
+
+### 4 — Scaffold the rule
+
+```typescript
+// Rationale: <one-line clinical justification with reference>
+{
+  trigger: /regex/i,
+  source: "Hebrew label shown to user",
+  group: "unique_snake_case",
+  triggerField: "diagnosis", // narrowest viable
+  tasks: [
+    { text: "...", urgency: "stat"|"urgent"|"routine"|"morning"|"extra",
+      category: "labs"|"meds"|"procedure"|"consult"|"other" },
+  ],
+},
+```
+
+### 5 — Confirm comfort-care suppression decision
+If the rule fires aggressive workup (labs, imaging, consults), verify:
+- `COMFORT_CARE_PATTERN` suppression already applies at the engine level, OR
+- The rule explicitly opts in/out with justification in a comment above the rule.
+
+DNR/DNI alone is NOT comfort care — do not treat it as suppression.
+
+### 6 — Write the regression test
+
+Add to `src/__tests__/rules.test.ts`:
+
+```typescript
+it("fires <rule name> on matching <trigger>", () => {
+  const patient = makePatient({ /* minimal fixture that hits the trigger */ });
+  const tasks = generateTasks(patient);
+  expect(tasks.some(t => t.generatedFrom === "<source>")).toBe(true);
+});
+
+it("does NOT fire <rule name> on comfort-care patient", () => {
+  const patient = makePatient({ diagnosis: "<trigger>", flags: ["comfort"] });
+  const tasks = generateTasks(patient);
+  expect(tasks.some(t => t.generatedFrom === "<source>")).toBe(false);
+});
+```
+
+### 7 — Bump the RULES.length assertion
+In `rules.test.ts`:
+```typescript
+expect(RULES.length).toBe(<N+1>);
+```
+Also check `rules.cross.test.ts` for counts or scenarios affected.
+
+### 8 — Run the mandatory workflow
+Invoke the `toranot-ship` skill OR manually:
+```
+npx tsc --noEmit && npx vitest run && npx vite build
+```
+
+## Checklist (print this before committing)
+
+- [ ] Rule passes the Golden Rule test (doctor-actionable this shift)
+- [ ] `group` is unique across all RULES
+- [ ] `triggerField` is the narrowest viable option
+- [ ] Rationale comment cites a source (Hazzard's / Harrison's / SZMC DAG)
+- [ ] Comfort-care suppression behavior is intentional + documented
+- [ ] Regression test added (positive case)
+- [ ] Negative test added (no fire on non-matching or comfort-care)
+- [ ] `expect(RULES.length).toBe(N+1)` bumped
+- [ ] `rules.cross.test.ts` updated if relevant
+- [ ] tsc + vitest + vite build all green
+
+## Anti-examples (do NOT ship these)
+
+```typescript
+// ❌ Nursing standing order — belongs to nursing team
+{ trigger: /דלקת עור/, tasks: [{ text: "להפוך מדי שעתיים", ... }] }
+
+// ❌ Morning team discharge planning
+{ trigger: /שחרור/, tasks: [{ text: "תאם עם סוציאלית", ... }] }
+
+// ❌ Textbook ladder as separate tasks
+{ trigger: /דליריום/, tasks: [
+  { text: "בדוק קלציום" },
+  { text: "בדוק TSH" },
+  { text: "בדוק B12" },
+  { text: "בדוק פולאט" },
+  { text: "בדוק אמוניה" },
+]}
+// ✅ Consolidate:
+{ trigger: /דליריום/, tasks: [
+  { text: "workup דליריום: Ca|TSH|B12|Folate|NH3", urgency: "urgent" }
+]}
+```

--- a/.claude/skills/toranot-ship/SKILL.md
+++ b/.claude/skills/toranot-ship/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: toranot-ship
+description: End-to-end Toranot ship pipeline. Runs the mandatory 7-step workflow (tsc, vitest, vite build, README update, git push with PAT rotation, Netlify deploy verification, auditor sweep). Use when user says "push", "push Toranot", "deploy", "ship Toranot", "ship it", "release", or any variant asking to ship Toranot to production. DO NOT use for watch-advisor2 or Shlav A Mega — this is Toranot-specific.
+disable-model-invocation: true
+---
+
+# Toranot Ship Pipeline
+
+Single-command production ship for `github.com/Eiasash/Toranot` → `toranot.netlify.app`.
+
+This skill is **user-invokable only** — Claude will not auto-run it, because it pushes to production and touches a live PAT.
+
+## Preconditions (ask the user if unclear)
+
+1. Working tree is in the Toranot repo root (usually `/home/claude/Toranot`).
+2. User has provided a **fresh GitHub PAT** for this session. Never store it. Paste into the `$GH_PAT` environment variable only.
+3. There are real, staged or unstaged changes worth shipping (`git status` not clean).
+4. User has edited the `README.md` Recent Changes section OR authorized this skill to add a terse one-liner.
+
+If any precondition is unmet, stop and ask.
+
+## Pipeline (Strict Order)
+
+Each step MUST pass before the next runs. On any failure: stop, surface the exact error, and do not proceed.
+
+### Step 1 — TypeScript gate
+```
+npx tsc --noEmit
+```
+Zero errors required. No suppressions.
+
+### Step 2 — Full vitest suite
+```
+npx vitest run --reporter=dot
+```
+All 1706 tests across 52 files must pass. If a new test was added, the new count is fine — but it must match the README/CLAUDE.md claim (update both in the same commit if the number moves).
+
+### Step 3 — Production build + bundle gate
+```
+npx vite build
+```
+Then assert main bundle stays under 150KB:
+```
+bash scripts/preflight.sh --bundle-gate
+```
+(Falls back to `du -sb dist/assets/index-*.js | awk '{ if ($1 > 153600) exit 1 }'`.)
+
+### Step 4 — README touch-up
+If the user did not update `README.md` Recent Changes, prompt for a one-line entry:
+```
+- YYYY-MM-DD: <short summary> (<short hash will go here>)
+```
+Commit it in the same commit as the feature.
+
+### Step 5 — Push with PAT rotation
+Uses `scripts/push-with-pat.sh`:
+1. `git remote set-url origin https://$GH_PAT@github.com/Eiasash/Toranot.git`
+2. `git config user.email "eias@toranot.app"`
+3. `git config user.name "Eias"`
+4. `git add -A && git commit -m "<type>: <description>" && git push origin main`
+5. **Immediately** `git remote set-url origin https://github.com/Eiasash/Toranot.git` (scrubs PAT)
+6. Print reminder: `Revoke at https://github.com/settings/tokens`
+
+Commit message convention: `feat:`, `fix:`, `refactor:`, `test:`, `chore:`, `docs:`.
+
+### Step 6 — Netlify deploy verification
+Uses `scripts/verify-deploy.sh`:
+- Poll `https://api.netlify.com/api/v1/sites/85d12386-b960-4f65-bee8-80e210ecd683/deploys?per_page=1`
+- Wait up to 5 minutes. State progression: `uploading → building → ready`.
+- On `ready`: assert `commit_ref` matches the just-pushed SHA.
+- On `error`: surface the build log URL, stop, do NOT mark success.
+
+### Step 7 — Post-deploy audit sweep
+Delegate to the `toranot-auditor` subagent with a fresh context. It checks:
+- Dismissed tasks leaking into aggregations
+- `RULES.length` assertion still matches `rules.ts`
+- Banned patterns (`transition-all`, `confirm()`, mid-file imports, `will-change` on `animate-card-in`)
+- `console.log` leaks
+- Test count drift between README/CLAUDE.md and actual vitest output
+- Bundle size still <150KB on the deployed build
+
+If the auditor flags anything, surface it as a follow-up — do not auto-fix on the same ship.
+
+## Failure modes + recovery
+
+| Failure | Action |
+|---------|--------|
+| tsc errors | Stop. Surface errors. Do NOT skip. |
+| vitest fails | Stop. Surface failing test names. Do NOT skip. |
+| Bundle >150KB | Stop. Run `npx vite-bundle-visualizer` or check lazy() coverage. |
+| Push rejected (non-fast-forward) | `git pull --rebase origin main`, resolve, retry. Never force-push `main`. |
+| Netlify stuck `building` >5 min | Trigger retry via Netlify MCP, re-poll. |
+| Netlify `error` | Fetch build logs, surface to user, do NOT declare success. |
+| Auditor findings | Surface as a `toranot-followups.md` note. User decides whether to ship a follow-up. |
+
+## Never do
+
+- Never `git push --force` to `main`.
+- Never leave the PAT in the git remote — always scrub immediately after push.
+- Never skip steps 1–3 to "just get it out".
+- Never edit `sw.js` `CACHE_VERSION` manually — Vite plugin stamps it.
+- Never merge changes that edited 1-of-5 room-format files without the other 4 (see `hooks/room-format-drift.js`).

--- a/.claude/skills/toranot-ship/scripts/preflight.sh
+++ b/.claude/skills/toranot-ship/scripts/preflight.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Toranot preflight: tsc → vitest → vite build → bundle size gate.
+# Exit codes:
+#   0 = all gates passed
+#   1 = tsc failed
+#   2 = vitest failed
+#   3 = vite build failed
+#   4 = bundle size gate failed
+#
+# Usage:
+#   bash .claude/skills/toranot-ship/scripts/preflight.sh          # full preflight
+#   bash .claude/skills/toranot-ship/scripts/preflight.sh --bundle-gate   # only the bundle gate
+set -euo pipefail
+
+BUNDLE_BUDGET_BYTES=${BUNDLE_BUDGET_BYTES:-153600}  # 150 * 1024
+
+bundle_gate() {
+  local max_size
+  if [[ ! -d dist ]]; then
+    echo "[preflight] no dist/ yet — run vite build first" >&2
+    return 4
+  fi
+  # Find the largest JS chunk (the main bundle), ignoring pre-gzipped .gz/.br
+  max_size=$(find dist/assets -name 'index-*.js' -not -name '*.gz' -not -name '*.br' -printf '%s\n' 2>/dev/null | sort -nr | head -1)
+  if [[ -z "$max_size" ]]; then
+    echo "[preflight] could not find dist/assets/index-*.js" >&2
+    return 4
+  fi
+  if (( max_size > BUNDLE_BUDGET_BYTES )); then
+    printf "[preflight] bundle %d bytes exceeds budget %d bytes\n" "$max_size" "$BUNDLE_BUDGET_BYTES" >&2
+    return 4
+  fi
+  printf "[preflight] bundle %d bytes OK (budget %d)\n" "$max_size" "$BUNDLE_BUDGET_BYTES"
+  return 0
+}
+
+if [[ "${1:-}" == "--bundle-gate" ]]; then
+  bundle_gate
+  exit $?
+fi
+
+echo "[preflight] step 1/4 — tsc --noEmit"
+if ! npx tsc --noEmit; then
+  echo "[preflight] tsc failed — fix type errors before shipping" >&2
+  exit 1
+fi
+
+echo "[preflight] step 2/4 — vitest run"
+if ! npx vitest run --reporter=dot; then
+  echo "[preflight] vitest failed — fix broken tests before shipping" >&2
+  exit 2
+fi
+
+echo "[preflight] step 3/4 — vite build"
+if ! npx vite build; then
+  echo "[preflight] vite build failed" >&2
+  exit 3
+fi
+
+echo "[preflight] step 4/4 — bundle size gate"
+bundle_gate || exit 4
+
+echo "[preflight] OK — safe to push"

--- a/.claude/skills/toranot-ship/scripts/push-with-pat.sh
+++ b/.claude/skills/toranot-ship/scripts/push-with-pat.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Safe push to Eiasash/Toranot with PAT rotation.
+# The PAT is injected into the remote URL only for the push, then scrubbed
+# back to a tokenless HTTPS URL IMMEDIATELY — even on failure.
+#
+# Usage:
+#   GH_PAT=ghp_xxx bash .claude/skills/toranot-ship/scripts/push-with-pat.sh "feat: description"
+#
+# Fails (non-zero exit) if:
+#   - GH_PAT is unset
+#   - commit message is missing
+#   - branch is not main
+#   - push fails
+#
+# On any exit path, scrub the remote.
+set -uo pipefail
+
+REPO_URL="https://github.com/Eiasash/Toranot.git"
+COMMITTER_NAME="Eias"
+COMMITTER_EMAIL="eias@toranot.app"
+
+scrub_remote() {
+  git remote set-url origin "$REPO_URL" 2>/dev/null || true
+}
+trap scrub_remote EXIT
+
+if [[ -z "${GH_PAT:-}" ]]; then
+  echo "[push] GH_PAT env var is required — paste your fresh PAT into the environment, do not commit it" >&2
+  exit 10
+fi
+
+COMMIT_MSG="${1:-}"
+if [[ -z "$COMMIT_MSG" ]]; then
+  echo "[push] commit message required as argument 1" >&2
+  exit 11
+fi
+
+# Enforce commit convention (feat:/fix:/refactor:/test:/chore:/docs:)
+if ! [[ "$COMMIT_MSG" =~ ^(feat|fix|refactor|test|chore|docs|perf|style)(\(.+\))?:\  ]]; then
+  echo "[push] commit message must start with type: — got: $COMMIT_MSG" >&2
+  exit 12
+fi
+
+CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CUR_BRANCH" != "main" ]]; then
+  echo "[push] refusing to ship from branch '$CUR_BRANCH' — switch to main first" >&2
+  exit 13
+fi
+
+if [[ -z "$(git status --porcelain)" ]]; then
+  echo "[push] nothing to commit — working tree clean" >&2
+  exit 14
+fi
+
+git config user.email "$COMMITTER_EMAIL"
+git config user.name "$COMMITTER_NAME"
+
+# Inject PAT ONLY for the push
+git remote set-url origin "https://${GH_PAT}@github.com/Eiasash/Toranot.git"
+
+git add -A
+if ! git commit -m "$COMMIT_MSG"; then
+  echo "[push] commit failed" >&2
+  exit 15
+fi
+
+if ! git push origin main; then
+  echo "[push] push failed — remote is scrubbed via trap; resolve and retry" >&2
+  exit 16
+fi
+
+SHA=$(git rev-parse --short HEAD)
+echo "[push] OK — pushed $SHA to main"
+echo "[push] REMINDER: revoke this PAT at https://github.com/settings/tokens"

--- a/.claude/skills/toranot-ship/scripts/verify-deploy.sh
+++ b/.claude/skills/toranot-ship/scripts/verify-deploy.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Poll Netlify API until the latest deploy for toranot.netlify.app is ready.
+# Asserts the deployed commit matches the just-pushed HEAD SHA.
+#
+# Usage:
+#   bash .claude/skills/toranot-ship/scripts/verify-deploy.sh
+#   NETLIFY_AUTH_TOKEN is optional — works without it (public site info),
+#   but authenticated polling gets higher rate limits.
+#
+# Exit codes:
+#   0 = deploy ready and commit_ref matches HEAD
+#   20 = timeout waiting for ready
+#   21 = deploy state = error
+#   22 = commit_ref mismatch
+set -euo pipefail
+
+SITE_ID="85d12386-b960-4f65-bee8-80e210ecd683"
+TIMEOUT_SEC=${TIMEOUT_SEC:-300}
+POLL_INTERVAL_SEC=${POLL_INTERVAL_SEC:-10}
+DEPLOYS_URL="https://api.netlify.com/api/v1/sites/${SITE_ID}/deploys?per_page=1"
+
+EXPECTED_SHA=$(git rev-parse HEAD)
+SHORT_SHA=${EXPECTED_SHA:0:7}
+echo "[verify] waiting for Netlify to deploy $SHORT_SHA …"
+
+AUTH_HEADER=()
+if [[ -n "${NETLIFY_AUTH_TOKEN:-}" ]]; then
+  AUTH_HEADER=(-H "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}")
+fi
+
+deadline=$(( $(date +%s) + TIMEOUT_SEC ))
+while :; do
+  now=$(date +%s)
+  if (( now > deadline )); then
+    echo "[verify] TIMEOUT after ${TIMEOUT_SEC}s — deploy did not reach 'ready'" >&2
+    exit 20
+  fi
+
+  body=$(curl -fsS "${AUTH_HEADER[@]}" "$DEPLOYS_URL" 2>/dev/null || echo "[]")
+  # Cheap JSON field extraction without jq dependency
+  state=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0].get('state','?') if d else '?')" 2>/dev/null || echo "?")
+  commit=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0].get('commit_ref','') if d else '')" 2>/dev/null || echo "")
+
+  printf "[verify] state=%s commit=%s\n" "$state" "${commit:0:7}"
+
+  case "$state" in
+    ready)
+      if [[ "$commit" == "$EXPECTED_SHA" ]]; then
+        echo "[verify] OK — deployed commit matches HEAD"
+        exit 0
+      fi
+      # It's possible a newer push is still in flight; keep polling briefly
+      echo "[verify] ready but commit mismatch (expected $SHORT_SHA, got ${commit:0:7}) — may be a prior deploy, polling again" >&2
+      ;;
+    error)
+      echo "[verify] Netlify deploy failed — state=error — check build logs in dashboard" >&2
+      exit 21
+      ;;
+    new|uploading|uploaded|preparing|prepared|building|processing|enqueued|"")
+      : # keep polling
+      ;;
+    *)
+      echo "[verify] unknown state: $state — continuing to poll" >&2
+      ;;
+  esac
+
+  sleep "$POLL_INTERVAL_SEC"
+done


### PR DESCRIPTION
## What this adds

Six Claude Code automations, all mapped to specific invariants already documented in `toranot-dev/SKILL.md`:

**Skills** (`.claude/skills/`)
- `toranot-ship` (user-only, `disable-model-invocation: true`) — runs the 7-step mandatory workflow in one command: `tsc --noEmit` → `vitest run` → `vite build` + 150KB bundle gate → README touch-up → push with PAT rotation → Netlify deploy polling → auditor sweep.
- `add-clinical-rule` — guided `src/engine/rules.ts` contribution. Checks the Golden Rule, scans for `group` collisions, scaffolds positive + comfort-care negative tests, bumps `RULES.length` assertion.

**Hooks** (`.claude/hooks/`)
- `ban-patterns.cjs` (PreToolUse, blocking) — blocks `transition-all`, `confirm()` in PWA code, `will-change` on `animate-card-in`, and mid-file `import` statements before the edit lands. Scoped to `src/**` and `public/**`; skips test files and `netlify/functions/`. Uses `.cjs` because the repo has `"type": "module"`.
- `room-format-drift.cjs` (PostToolUse, advisory) — warns when one of the 6 room-format touchpoints (parser, AddAdmissionModal, Scanner, VoiceInput, QuickCaptureSheet, roomFormat.simulation.test.ts) is edited without the others. Only fires when the edit actually contains room-parsing signals.

**Subagents** (`.claude/agents/`)
- `toranot-auditor` — post-change regression sweep: dismissed-task leaks, `RULES.length` drift, banned patterns, `console.log` leaks, test-count drift between README/CLAUDE.md and actual vitest output, bundle size, import-graph breakage.
- `rules-engine-reviewer` — paranoid reviewer for `src/engine/rules.ts` and `drugSafety.ts`. Enforces Golden Rule (doctor-actionable tasks only), unique `group` keys, comfort-care suppression correctness, trigger-field narrowness, and regression-test presence.

**Settings merge**
`.claude/settings.json` was merged non-destructively:
- Kept the existing PostToolUse Bash hook (push-main reminder).
- Added the two new Edit/Write/MultiEdit hooks.
- Unioned `permissions.allow` — no existing entries removed.

## What's NOT touched

- `.claude/commands/*` — left untouched (7 existing slash commands preserved).
- `.claude/toranot-settings.json` — left untouched (appears to be a duplicate of settings.json; see "Follow-ups").

## Overlap to decide on

`/toranot-audit-fix-deploy` in `commands/` overlaps heavily with the new `toranot-ship` skill. They do roughly the same 7-step workflow. My recommendation: keep `toranot-ship` (skill) and remove the command, because skills with `disable-model-invocation: true` enforce "user-initiated only" at the runtime level, which matters for a pipeline that pushes to production. Happy to do that consolidation as a follow-up.

## Verification

Smoke-tested 12 hook scenarios in the sandbox:

| # | Scenario | Expected | Actual |
|---|----------|----------|--------|
| 1 | `transition-all` in src/App.tsx | BLOCK | BLOCK |
| 2 | `confirm()` in src component | BLOCK | BLOCK |
| 3 | `transition-colors` (clean) | PASS | PASS |
| 4 | `confirm()` in netlify/functions | PASS | PASS |
| 5 | Banned pattern in `__tests__/` | PASS | PASS |
| 6 | Mid-file `import` in src | BLOCK | BLOCK |
| 6b | Top-of-file imports (clean) | PASS | PASS |
| 7 | `will-change` on `animate-card-in` | BLOCK | BLOCK |
| 8 | Absolute path (`/home/claude/Toranot/src/...`) | BLOCK | BLOCK |
| 9 | Room-parser edit with ROOM_PATTERN | WARN | WARN (5 peers listed) |
| 10 | Room-parser edit without room signals | silent | silent |
| 11 | Settings.json parses as valid JSON | OK | OK |
| 12 | Malformed JSON input to hook | exit 0 (no crash) | exit 0 |

Two real bugs caught during verification and fixed before commit:
- Hooks initially written as `.js` — fails under `"type": "module"` package.json. Renamed to `.cjs`.
- `inScope` path regex required leading slash — missed relative paths like `src/App.tsx`. Fixed to `(^|\/)(src|public)\/`.

## How to use after merge

Ship a change:
```
/toranot-ship
```
(Will prompt for a fresh `GH_PAT` in the shell env.)

Add a clinical rule:
```
/add-clinical-rule
```

Manual subagent invocation:
```
@toranot-auditor please run a full sweep
@rules-engine-reviewer review the last commit to src/engine/rules.ts
```

Hooks fire automatically on every Edit/Write/MultiEdit inside the repo.

## Reminder

Please revoke the PAT I was given for this push at https://github.com/settings/tokens after you've reviewed.
