### PR TITLE
Add cowork plugin: branch + handoff workflow for Toranot

### DIFF
--- a/plugins/cowork/.claude-plugin/plugin.json
+++ b/plugins/cowork/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "cowork",
+  "version": "0.1.0",
+  "description": "Cowork branch + session-handoff workflow tuned for Toranot's clinical rules engine and SZMC notes. Commands, agents, skills, and SessionStart hook for resuming work cleanly across Claude sessions.",
+  "author": { "name": "eiasash" },
+  "keywords": ["cowork", "handoff", "clinical", "rules-engine", "szmc"],
+  "homepage": "https://github.com/eiasash/toranot"
+}

--- a/plugins/cowork/README.md
+++ b/plugins/cowork/README.md
@@ -1,0 +1,61 @@
+# cowork (Toranot)
+
+Local Claude Code plugin that formalizes the `cowork/<topic>` branch + session-handoff workflow for **Toranot**: SZMC clinical notes + the rules engine in `src/engine/rules.ts`.
+
+## Install (local)
+
+```bash
+# from repo root
+mkdir -p .claude/plugins
+ln -sfn "$PWD/plugins/cowork" .claude/plugins/cowork
+```
+
+Or reference as a marketplace entry in `~/.claude/settings.json`.
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `/cowork:start <slug>` | Cut `cowork/<slug>`, scaffold `.cowork/<slug>.md` handoff, commit |
+| `/cowork:handoff` | Write/refresh the handoff file: branch, staged diff, open todos, failing tests, next step |
+| `/cowork:resume` | Read current branch's handoff, run `npm test`, summarize delta since handoff |
+| `/cowork:status` | List every `cowork/*` branch: ahead/behind main, last handoff note, rule-count delta |
+| `/cowork:land` | Rebase on main, enforce golden-rule invariant, run vitest + typecheck, prep squash message |
+| `/cowork:sbar` | Generate Hebrew SBAR handoff for a SZMC note (rotation-level, not rules) |
+| `/cowork:pair-rule <trigger>` | Pair-program a new clinical rule with the add-clinical-rule skill |
+
+## Agents
+
+- `clinical-reviewer` — reviews a rule/note diff for golden-rule compliance, comfort-care suppression, Hebrew term consistency, and Beers/STOPP overlap.
+
+## Hooks
+
+- `SessionStart` — if the current branch is `cowork/*`, prints its handoff file and the last 5 commits so Claude can resume without prompting.
+
+## Handoff file format
+
+`.cowork/<slug>.md` — plain markdown, one per active topic. Committed so every session can read it.
+
+```md
+# <slug>
+
+**Branch:** cowork/<slug>
+**Last session:** 2026-04-18 (Claude Opus 4.7)
+**Status:** in-progress | blocked | ready-to-land
+
+## Goal
+One paragraph.
+
+## Done
+- ...
+
+## Next
+- [ ] concrete next tool call
+
+## Tests
+- `npm test -- rules.polypharmacy` : PASS
+- `npm run typecheck` : PASS
+
+## Notes for the next Claude
+Anything non-obvious.
+```

--- a/plugins/cowork/agents/clinical-reviewer.md
+++ b/plugins/cowork/agents/clinical-reviewer.md
@@ -1,0 +1,26 @@
+---
+name: clinical-reviewer
+description: Reviews a Toranot rules-engine or clinical-note diff for golden-rule compliance, comfort-care suppression, Hebrew term consistency, and Beers/STOPP overlap. Use before running /cowork:land or when the user asks for a second opinion on a clinical change.
+tools: Read, Grep, Glob, Bash
+---
+
+You are an independent reviewer. You have not seen the drafting session. Review what's actually in the diff — not what the author says they did.
+
+**Scope check first.** `git diff main...HEAD --stat`. If the diff touches things outside `src/engine/rules.ts`, `src/engine/drugSafety.ts`, notes data, or tests, note it and focus your review on the clinical surface only.
+
+**For every new/changed rule in `src/engine/rules.ts`:**
+1. **Golden-rule invariant** — does the rule have a unique `group` and a comfort-care suppression branch? If not, that's a blocker.
+2. **Test coverage** — does `src/engine/__tests__/` contain: (a) a positive test, (b) a comfort-care negative test, (c) an exception-list negative test? Missing → blocker.
+3. **Duplication with drugSafety** — if this rule is really a drug-drug interaction, call it out. `drugSafety.ts` is the right place for those.
+4. **Beers/STOPP overlap** — if the trigger matches an existing Beers/STOPP entry, check whether the existing entry already fires. Silent duplicate firing is a UX bug.
+
+**For Hebrew clinical text** (notes, UI strings):
+5. Use the hebrew-medical-glossary skill as the source of truth. Flag any term that deviates from Clalit/Maccabi conventions. Do not invent rewrites — just flag.
+6. RTL punctuation: `.` at end of sentence, not `.` after a Hebrew word with English drug name following — check direction marks.
+
+**Report** in under 250 words:
+- **Blockers** (must fix before land) — numbered.
+- **Worth discussing** — non-blocking.
+- **Safe to land** — yes/no.
+
+Do not rewrite the code. Do not call Edit/Write. Your job is the second opinion, not the fix.

--- a/plugins/cowork/commands/handoff.md
+++ b/plugins/cowork/commands/handoff.md
@@ -1,0 +1,17 @@
+---
+description: Write or refresh the handoff file for the current cowork branch
+---
+
+Refresh `.cowork/<slug>.md` for the current branch so the next Claude session can resume cold.
+
+1. `git rev-parse --abbrev-ref HEAD` — must start with `cowork/`. If not, stop.
+2. `git status --porcelain`, `git diff --stat main...HEAD`, `git log --oneline main..HEAD`.
+3. Run `npm test --silent` and `npm run typecheck` (if present). Capture pass/fail per suite — do NOT paste full output.
+4. Update the handoff file:
+   - **Status** — `in-progress` unless all tests pass and diff looks landable (`ready-to-land`), or unless you hit an unresolved error (`blocked: <one line>`).
+   - **Done** — bullet what got added/changed since the previous handoff, grouped by concern (rule, test, UI, supabase).
+   - **Next** — one concrete next action. Must be a tool call or file path, not a vague verb.
+   - **Tests** — one line per suite with PASS/FAIL.
+   - **Notes for the next Claude** — ONLY include non-obvious things: intentional workarounds, half-finished refactors, why a test is skipped, a rules-engine invariant you almost broke.
+5. `git add .cowork/ && git commit -m "cowork: handoff"`. Do not push.
+6. Print the updated file so the user can read it.

--- a/plugins/cowork/commands/land.md
+++ b/plugins/cowork/commands/land.md
@@ -1,0 +1,12 @@
+---
+description: Land the current cowork branch onto main — enforce golden-rule invariant, tests, typecheck, then prep a squash message
+---
+
+You are about to merge a cowork branch. Be slow and careful — this affects shared state.
+
+1. Branch check: `git rev-parse --abbrev-ref HEAD` must start with `cowork/`. Abort otherwise.
+2. `git fetch origin main && git rebase origin/main`. If conflicts, STOP and print them. Do not auto-resolve clinical rule conflicts.
+3. Golden-rule invariant check (Toranot-specific): if `src/engine/rules.ts` changed, grep the diff for every new `id:` and confirm each has (a) a unique group, (b) a comfort-care suppression branch, (c) a matching test in `src/engine/__tests__/`. Missing any → block and list what's missing.
+4. `npm test --silent` — all suites must pass. `npm run typecheck`. `npm run build` if fast.
+5. Read `.cowork/<slug>.md`. Draft a squash-merge message: first line `<type>(scope): <goal>`, body = the **Done** bullets, footer = `Cowork-branch: cowork/<slug>`.
+6. Print the draft message and the commands the user needs to run (`git checkout main`, `git merge --squash cowork/<slug>`, etc.). Do NOT merge or push yourself — this is a confirmation step.

--- a/plugins/cowork/commands/pair-rule.md
+++ b/plugins/cowork/commands/pair-rule.md
@@ -1,0 +1,14 @@
+---
+description: Pair-program a new clinical rule in src/engine/rules.ts with the add-clinical-rule skill
+argument-hint: <trigger-phrase>  (e.g. "PPI + clopidogrel")
+---
+
+Start a pair-programming loop to add a rule.
+
+1. Invoke the `add-clinical-rule` skill — it owns the schema, golden-rule invariant, and test scaffolding. Pass `$ARGUMENTS` as the trigger.
+2. While the skill proposes the rule, you:
+   - Check `src/engine/rules.ts` for a rule with an overlapping group — duplicate groups are a bug.
+   - Check `src/engine/drugSafety.ts` — if the trigger is really a drug-drug interaction, the rule belongs there instead. STOP and tell the user.
+   - Confirm the proposed test covers (a) fire, (b) no-fire when comfort-care is set, (c) no-fire when the drug is on an exception list.
+3. After the rule is written, update `.cowork/<slug>.md` → **Done** with the rule id, and **Tests** with the new suite name.
+4. Do NOT commit — let the user read the diff first.

--- a/plugins/cowork/commands/resume.md
+++ b/plugins/cowork/commands/resume.md
@@ -1,0 +1,13 @@
+---
+description: Resume a cowork session by reading its handoff and verifying state
+---
+
+You are picking up a cowork session cold. Do NOT ask the user what was going on — read the handoff.
+
+1. `git rev-parse --abbrev-ref HEAD`. If not `cowork/*`, ask which branch to check out, then `git checkout` it.
+2. Read `.cowork/<slug>.md`. Print **Goal**, **Next**, **Notes for the next Claude** verbatim.
+3. Verify state hasn't drifted since handoff:
+   - `git log --oneline -5`
+   - `git status --porcelain` (uncommitted stuff is suspicious — flag it)
+   - `npm test --silent` and `npm run typecheck`. If any suite that was PASS in the handoff is now FAIL, STOP and flag the regression before doing new work.
+4. State in one sentence what you are about to do, mapped to the **Next** bullet.

--- a/plugins/cowork/commands/sbar.md
+++ b/plugins/cowork/commands/sbar.md
@@ -1,0 +1,15 @@
+---
+description: Generate a Hebrew SBAR handoff for a SZMC clinical note (rotation shift handoff, not rules-engine work)
+argument-hint: <note-id or patient-slug>
+---
+
+Produce a SBAR-formatted handoff in **Hebrew** from the note data. Do NOT invent patient data — read from the app's stored note (src/data/notes/, Supabase row, or whatever the current page is showing).
+
+Structure (labels Hebrew-RTL, body Hebrew):
+
+- **מצב (Situation)** — one sentence: age, sex, ward, primary reason.
+- **רקע (Background)** — comorbidities + active meds, STOPP/Beers flags if the rules engine fired any (use the actual fired rule id).
+- **הערכה (Assessment)** — current problem list with priority, any pending workup.
+- **המלצה (Recommendation)** — specific actions for the next shift, owners, time horizon.
+
+Follow Israeli MoH / Clalit conventions from the hebrew-medical-glossary skill. Do not translate drug names; keep generic English with Hebrew trade name in parens if the note has one.

--- a/plugins/cowork/commands/start.md
+++ b/plugins/cowork/commands/start.md
@@ -1,0 +1,16 @@
+---
+description: Cut a new cowork/<slug> branch off main and scaffold its handoff file
+argument-hint: <slug>  (kebab-case topic, e.g. polypharmacy-v3)
+---
+
+You are starting a new Toranot cowork session.
+
+1. Read the current branch with `git rev-parse --abbrev-ref HEAD`. If it is not `main`, stop and ask — do not stack cowork branches.
+2. `git fetch origin main && git checkout -b cowork/$ARGUMENTS origin/main`.
+3. Create `.cowork/$ARGUMENTS.md` using the template in `plugins/cowork/README.md`. Fill in:
+   - **Goal** — ask the user one sentence if you can't infer it.
+   - **Done** — empty.
+   - **Next** — `[ ] define scope`.
+   - **Tests** — run `npm test --silent 2>&1 | tail -20` and paste the result.
+4. `git add .cowork/$ARGUMENTS.md && git commit -m "cowork: start $ARGUMENTS"`.
+5. Print the branch name and the path to the handoff file. Do not push — let the user review first.

--- a/plugins/cowork/commands/status.md
+++ b/plugins/cowork/commands/status.md
@@ -1,0 +1,14 @@
+---
+description: List all cowork/* branches with ahead/behind, handoff status, and rule-count delta
+---
+
+Survey all cowork branches so the user can decide which to land, resume, or abandon.
+
+1. `git fetch origin --prune`.
+2. `git for-each-ref --format='%(refname:short)' refs/heads/cowork refs/remotes/origin/cowork` — dedupe.
+3. For each branch, compute in parallel:
+   - `git rev-list --left-right --count origin/main...<branch>` → ahead/behind main.
+   - Read `.cowork/<slug>.md` if present; extract **Status** and **Last session** lines.
+   - Rule-count delta: `git show <branch>:src/engine/rules.ts 2>/dev/null | grep -c "id:"` minus same on main.
+4. Print a markdown table: `branch | status | ahead/behind | rule delta | last session`.
+5. End with a one-line recommendation: which branch to land first (smallest diff + `ready-to-land`), which looks stale (>14 days old handoff).

--- a/plugins/cowork/hooks/hooks.json
+++ b/plugins/cowork/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); case \"$branch\" in cowork/*) slug=${branch#cowork/}; echo \"=== cowork session: $branch ===\"; if [ -f \".cowork/$slug.md\" ]; then cat \".cowork/$slug.md\"; else echo \"(no handoff file at .cowork/$slug.md — run /cowork:handoff)\"; fi; echo; echo \"--- last 5 commits ---\"; git log --oneline -5; ;; esac'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/cowork/skills/handoff-format/SKILL.md
+++ b/plugins/cowork/skills/handoff-format/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: handoff-format
+description: Canonical format for Toranot `.cowork/<slug>.md` handoff files. Load whenever writing or reading a handoff. Enforces the five required sections and what belongs in each.
+---
+
+# cowork handoff format (Toranot)
+
+Handoff files live at `.cowork/<slug>.md`, one per active cowork branch, committed to the branch.
+
+## Required sections, in order
+
+### Header
+```
+# <slug>
+
+**Branch:** cowork/<slug>
+**Last session:** YYYY-MM-DD (model)
+**Status:** in-progress | blocked: <reason> | ready-to-land
+```
+
+### Goal
+One paragraph. What is this branch trying to achieve, in the language of the rules engine / clinical note / SZMC workflow. Never rewrite after the first session — this is the anchor.
+
+### Done
+Bulleted, grouped by concern. Each bullet names a concrete artifact:
+- `src/engine/rules.ts` — added rule `polypharmacy-anticoag-v2` (group: polypharmacy-anticoag).
+- `src/engine/__tests__/rules.test.ts` — 3 new cases, all pass.
+- NOT allowed: `cleaned up some stuff`, `improved error handling`. Be specific or omit.
+
+### Next
+One or two bullets, each a concrete next action. Use imperative voice that names the file and the change.
+- `[ ] Add test for comfort-care suppression in src/engine/__tests__/rules.test.ts`.
+- NOT allowed: `[ ] Continue the work`, `[ ] Review`.
+
+### Tests
+One line per suite, current state:
+- `npm test -- rules` : PASS
+- `npm run typecheck` : PASS
+- `npm test -- drugSafety` : FAIL (1 pre-existing, unrelated)
+
+### Notes for the next Claude
+Only non-obvious things. If a future reader would ask "why?", answer here. Examples:
+- Why a test is `.skip`ped and under what condition to re-enable.
+- A rule you deliberately did NOT add because it overlaps with drugSafety.ts.
+- A half-finished Hebrew rewrite waiting on glossary clarification.
+
+## What NOT to include
+- A summary of the conversation with the user — use commit messages.
+- Restatements of the diff — use `git diff`.
+- Plans that could be follow-up branches — use GitHub issues.


### PR DESCRIPTION
## Summary
Introduces a comprehensive Claude plugin that formalizes the `cowork/<topic>` branch and session-handoff workflow for Toranot's clinical rules engine. This enables clean, structured collaboration across multiple Claude sessions with built-in safeguards for clinical rule changes.

## Key Changes

- **Plugin structure** (`plugin.json`) — registers the cowork plugin with metadata and keywords
- **Commands** (8 total):
  - `/cowork:start <slug>` — scaffold a new cowork branch with handoff template
  - `/cowork:handoff` — write/refresh the session handoff file
  - `/cowork:resume` — read handoff and verify state hasn't drifted
  - `/cowork:status` — survey all cowork branches with ahead/behind, rule deltas, and handoff age
  - `/cowork:land` — rebase, enforce golden-rule invariant, run tests, prep squash message
  - `/cowork:sbar` — generate Hebrew SBAR shift handoff from clinical notes
  - `/cowork:pair-rule <trigger>` — pair-program new rules with the add-clinical-rule skill
- **Agents**:
  - `clinical-reviewer` — independent review of rule/note diffs for golden-rule compliance, comfort-care suppression, Hebrew term consistency, and Beers/STOPP overlap
- **Skills**:
  - `handoff-format` — canonical format spec for `.cowork/<slug>.md` files with required sections (Goal, Done, Next, Tests, Notes for the next Claude)
- **Hooks**:
  - `SessionStart` — auto-prints handoff file and last 5 commits when resuming a cowork branch
- **Documentation** (`README.md`) — install instructions, command reference, agent/hook/handoff format overview

## Notable Implementation Details

- Handoff files are committed to the branch so every session can read them without network calls
- Golden-rule invariant enforcement at land time: every new rule must have a unique group, comfort-care suppression branch, and matching test coverage
- Clinical reviewer is scoped to clinical surface only; flags scope violations but focuses review on rules/notes
- Hebrew SBAR generation uses the hebrew-medical-glossary skill as source of truth for Clalit/Maccabi conventions
- Status command dedupes local and remote cowork branches and recommends landing order (smallest diff + ready-to-land first)
- Resume command stops and flags test regressions before proceeding with new work

https://claude.ai/code/session_015ZKmUZvbKfbSWqxrom9NMS