### PR TITLE
fix(drugSafety): reject clinically impossible CrCl inputs

### DIFF
--- a/src/__tests__/drugSafety.edge.test.ts
+++ b/src/__tests__/drugSafety.edge.test.ts
@@ -202,6 +202,28 @@ describe("calculateCrCl — additional edge cases", () => {
     // (140-30)*70/(72*0.3) = 7700/21.6 ≈ 356
     expect(result).toBeGreaterThan(300);
   });
+
+  it("returns null for age below adult range (age < 18)", () => {
+    expect(calculateCrCl(12, 1.0, 70, false)).toBeNull();
+  });
+
+  it("returns null for implausible age (age > 120)", () => {
+    // Typo like 180 instead of 80 should not silently produce negative CrCl
+    expect(calculateCrCl(180, 1.0, 70, false)).toBeNull();
+  });
+
+  it("returns null for implausibly high creatinine (> 20)", () => {
+    expect(calculateCrCl(70, 25, 70, false)).toBeNull();
+  });
+
+  it("returns null for implausibly low weight (< 20 kg)", () => {
+    expect(calculateCrCl(80, 1.0, 10, false)).toBeNull();
+  });
+
+  it("returns null for implausibly high weight (> 250 kg)", () => {
+    // Typo like 900 instead of 90 should not produce nonsensical CrCl
+    expect(calculateCrCl(80, 1.0, 900, false)).toBeNull();
+  });
 });
 
 // ═════════════════════════════════════════════════════════════

--- a/src/engine/drugSafety.ts
+++ b/src/engine/drugSafety.ts
@@ -372,6 +372,14 @@ export function calculateCrCl(
   isFemale?: boolean,    // optional, default false
 ): number | null {
   if (!age || !creatinine || creatinine <= 0) return null;
+  // Reject clinically impossible inputs — protects against typos
+  // (e.g. weight "900" instead of "90") that would silently produce
+  // nonsensical CrCl values and drive incorrect renal dose warnings.
+  if (age < 18 || age > 120) return null;
+  if (creatinine > 20) return null;
+  // Weight range matches the clinicalMeta sanity bounds used by callers
+  // (see checkRenalDoseWarnings: weightKg must be 20-250 to be trusted).
+  if (weight !== undefined && (weight < 20 || weight > 250)) return null;
   // Apply creatinine floor for frail elderly (≥75yo) — prevents CrCl overestimation
   const cr = age >= 75 && creatinine < 1.0 ? 1.0 : creatinine;
   const w = weight ?? 70;


### PR DESCRIPTION
## Summary

Deep-audit finding applied as a surgical fix. `calculateCrCl()` in `src/engine/drugSafety.ts` previously accepted any numeric inputs and silently produced nonsensical values when fed typo-level data (e.g. age 180 instead of 80, weight 900 instead of 90). Those values then flowed into `checkRenalDoseWarnings` and could drive incorrect renal-dose alerts.

This change rejects inputs outside clinically plausible bounds and returns `null`, matching the function's existing "insufficient data" contract.

## Scope

- `src/engine/drugSafety.ts` — add bounds: age ∈ [18, 120], creatinine ≤ 20 mg/dL, weight ∈ [20, 250] kg (aligned with the existing `clinicalMeta.weightKg` sanity range already used by the caller).
- `src/__tests__/drugSafety.edge.test.ts` — 5 new edge-case tests.

## Audit findings intentionally NOT included

Security and clinical-data findings that require coordination were intentionally left out of this PR:

- **Secrets/RLS**: `AI_SECRET` and `VITE_SUPABASE_ANON_KEY` rotation require backend/Supabase-console access.
- **Clinical data changes**: e.g. adding new drug-interaction rows (ACE-I + NSAID) needs clinical sign-off.
- **Behavior changes**: e.g. comfort-care task re-generation on GOC change requires a protocol decision.
- **Large refactors**: migrating AI-reasoning rendering to `react-markdown` + `rehype-sanitize` is a larger defense-in-depth refactor; current DOMPurify path is safe.
- **Pre-existing deliberate design**: e.g. `parseFreestyle`'s hyphen-only room separator has a code comment explaining the deliberate RTL-ambiguity tradeoff.

## Test plan

- [x] `npm test` — 2,207 tests pass (up from 2,202 with the 5 new bounds tests)
- [x] `npm run typecheck` — clean
- [ ] Manual smoke: enter admission with weight 900, confirm no renal warning instead of bad CrCl

https://claude.ai/code/session_018yS2e68SpoHJXC15ZJH8Hb