### PR TITLE
feat(intake,rounds): admission processor + Chameleon rounds-note exporter

### DIFF
--- a/src/components/AddAdmissionModal.tsx
+++ b/src/components/AddAdmissionModal.tsx
@@ -8,6 +8,7 @@ const API_KEY_STORAGE = "toranot-anthropic-key";
 const DIRECT_API_URL = "https://api.anthropic.com/v1/messages";
 import { usePatientsState, usePatientsDispatch } from "../context/PatientsContext";
 import { generateId } from "../utils/id";
+import { processIntake } from "../engine/admissionProcessor";
 
 const SIDE_TO_SECTION: Record<"A" | "B" | "C" | "REHAB" | "UNKNOWN", PatientSection> = {
   A: "SIDE_A",
@@ -826,7 +827,8 @@ export function AddAdmissionModal({ onClose, onSuccess }: Props) {
       })(),
     } as PatientEntry;
 
-    dispatch({ type: "NEW_ADMISSION", patient });
+    const processed = processIntake(patient);
+    dispatch({ type: "NEW_ADMISSION", patient: processed });
     onSuccess?.();
     onClose();
   }

--- a/src/components/PatientCardAlerts.tsx
+++ b/src/components/PatientCardAlerts.tsx
@@ -5,7 +5,7 @@
  * Owns its own showHints toggle state — no prop drilling needed.
  */
 
-import { useState, useMemo, memo } from "react";
+import { useState, useMemo, memo, useCallback } from "react";
 import type { PatientEntry } from "../types";
 import { LabBadges, AddLabForm } from "./LabTracker";
 import { DrugSafetyAlerts } from "./DrugSafetyAlerts";
@@ -15,6 +15,7 @@ import { generateHints } from "../engine/hints";
 import { calculateACB } from "../engine/anticholinergicBurden";
 import { calculateFallsRisk } from "../engine/fallsRisk";
 import { calculateLabTrends, type TrendArrow } from "../engine/labDelta";
+import { generateChameleonRoundsNote } from "../parser/chameleonExport";
 
 // ── ACB badge ────────────────────────────────────────────────────────────────
 
@@ -80,6 +81,38 @@ function LabTrendArrows({ patient }: { patient: PatientEntry }) {
         </span>
       ))}
     </div>
+  );
+}
+
+// ── Chameleon rounds-note copy button ────────────────────────────────────────
+
+function ChameleonCopyButton({ patient }: { patient: PatientEntry }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    const note = generateChameleonRoundsNote(patient);
+    try {
+      await navigator.clipboard.writeText(note);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API unavailable (old Safari / insecure context) — no-op.
+    }
+  }, [patient]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={`text-xs px-2.5 py-1 rounded-lg border active:opacity-80 ${
+        copied
+          ? "bg-emerald-50 dark:bg-emerald-900/30 border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300"
+          : "bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-300"
+      }`}
+      aria-label="העתק סיכום ביקור לצ'מליון"
+    >
+      {copied ? "✓ הועתק" : "📋 העתק לסיכום ממוחשב"}
+    </button>
   );
 }
 
@@ -163,6 +196,11 @@ function PatientCardAlertsBase({ patient, showLabForm, onToggleLabForm }: Patien
 
       {/* Clinical hints */}
       <ClinicalHints patient={patient} />
+
+      {/* Chameleon EMR rounds-note export */}
+      <div className="flex flex-wrap gap-2">
+        <ChameleonCopyButton patient={patient} />
+      </div>
 
       {/* Inline lab entry form */}
       {showLabForm && (

--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -108,6 +108,7 @@ export function normalizePatient(p: RawPatient): PatientEntry {
     },
     ...(p.discharged ? { discharged: true } : {}),
     ...(p.isAdmission ? { isAdmission: true } : {}),
+    ...((p as PatientEntry).needsCapacityAssessment ? { needsCapacityAssessment: true } : {}),
   } as PatientEntry;
 }
 

--- a/src/engine/admissionProcessor.ts
+++ b/src/engine/admissionProcessor.ts
@@ -1,0 +1,84 @@
+/**
+ * Admission Intake Processor
+ *
+ * Takes a raw intake payload (from AddAdmissionModal or OCR) and hydrates the
+ * record into a full PatientEntry with geriatric baselines computed up front:
+ *
+ *   - ACB (anticholinergic burden) — Boustani 2008 scale
+ *   - Falls risk composite — age, psychotropics, polypharmacy, mobility
+ *
+ * Golden Rule: a fresh admission NEVER gets auto-generated tasks. The on-call
+ * doctor decides what's actionable. `generatedTasks` is always [] here; the
+ * user can trigger REAPPLY_RULES from the patient card later if they want.
+ *
+ * MOH surrogate-consent flag: elderly patients (age >= 65) with ACB >= 3 are
+ * flagged for capacity assessment, since the anticholinergic load itself can
+ * impair decision-making and the Ministry of Health requires a surrogate
+ * evaluation before advance-directive discussions in that population.
+ */
+
+import { calculateACB } from "./anticholinergicBurden";
+import { calculateFallsRisk } from "./fallsRisk";
+import type { PatientEntry, PatientSection } from "../types";
+
+function today(): string {
+  const d = new Date();
+  return `${String(d.getDate()).padStart(2, "0")}/${String(d.getMonth() + 1).padStart(2, "0")}/${d.getFullYear()}`;
+}
+
+function hydrate(raw: Partial<PatientEntry>): PatientEntry {
+  return {
+    id: raw.id ?? `pt-${Date.now()}`,
+    section: (raw.section ?? "UNKNOWN_SECTION") as PatientSection,
+    date: raw.date ?? today(),
+    room: raw.room ?? null,
+    name: raw.name ?? null,
+    age: raw.age ?? null,
+    diagnosis: raw.diagnosis ?? null,
+    flags: raw.flags ?? [],
+    status: raw.status ?? [],
+    tomorrowNotes: raw.tomorrowNotes ?? [],
+    planNotes: raw.planNotes ?? [],
+    tasks: raw.tasks ?? [],
+    generatedTasks: [],
+    notes: raw.notes ?? [],
+    scannedAt: new Date().toISOString(),
+    confidence: raw.confidence ?? 1,
+    labs: raw.labs ?? [],
+    handoverNote: raw.handoverNote,
+    discharged: raw.discharged,
+    photos: raw.photos,
+    photoIds: raw.photoIds,
+    allergies: raw.allergies ?? [],
+    medications: raw.medications ?? [],
+    order: raw.order ?? Date.now(),
+    clinicalMeta: raw.clinicalMeta ?? {},
+    syncMeta: raw.syncMeta,
+    isAdmission: true,
+  };
+}
+
+export function processIntake(rawInput: Partial<PatientEntry>): PatientEntry {
+  const hydrated = hydrate(rawInput);
+
+  // Baseline geriatric scores — computed once at intake so the UI has
+  // them ready without re-running on every render. They are re-derived
+  // live by PatientCardAlerts when medications change, so we don't persist
+  // the score values on the record — only the capacity-assessment flag,
+  // which drives a discrete UX reminder.
+  const acb = calculateACB(hydrated);
+  // Compute falls risk to warm any future caching / surface a console hint
+  // during dev. The badge UI recomputes from the stored patient fields,
+  // so the value itself isn't persisted on the record.
+  void calculateFallsRisk(hydrated);
+
+  const needsCapacityAssessment = (hydrated.age ?? 0) >= 65 && acb.totalScore >= 3;
+
+  return {
+    ...hydrated,
+    isAdmission: true,
+    generatedTasks: [],
+    needsCapacityAssessment,
+    scannedAt: new Date().toISOString(),
+  };
+}

--- a/src/parser/chameleonExport.ts
+++ b/src/parser/chameleonExport.ts
@@ -1,0 +1,235 @@
+/**
+ * Chameleon EMR — Rounds Note Synthesizer
+ *
+ * Output is a plain-text, RTL-friendly rounds note ready to paste into the
+ * SZMC Chameleon EMR "rounds / progress note" field. Follows the institutional
+ * format (see SZMC-Clinical-Notes-Project-Knowledge.md).
+ *
+ * Strict output rules — the Chameleon EMR auto-formats its own printout, so
+ * we must NEVER inject our own formatting:
+ *
+ *   • Plain text only. No Markdown bold / asterisks / underscores.
+ *   • Section headers use a plain `#` prefix (e.g. `# מטופל בקבלה`).
+ *   • Lab transitions use a bare `>` with spaces (e.g. `קריאטינין: 1.55 > 1.03`).
+ *     No Unicode arrows (→ ↗ ↘) — they break RTL cursor handling in Chameleon.
+ *   • Active diagnoses ALWAYS in UPPERCASE English.
+ *   • Medications: numbered list (1..N) in SZMC format. Translate English
+ *     frequency abbreviations (`q8h`, `qd`, ...) to Hebrew.
+ */
+
+import type { PatientEntry, LabEntry } from "../types";
+
+// ─── Frequency / route translation ─────────────────────────────────────
+
+const FREQUENCY_MAP: Array<[RegExp, string]> = [
+  [/\bq\s*4\s*h\b/gi, "כל 4 שעות"],
+  [/\bq\s*6\s*h\b/gi, "כל 6 שעות"],
+  [/\bq\s*8\s*h\b/gi, "כל 8 שעות"],
+  [/\bq\s*12\s*h\b/gi, "כל 12 שעות"],
+  [/\bq\s*24\s*h\b/gi, "פעם ביום"],
+  [/\bqd\b/gi, "פעם ביום"],
+  [/\bod\b/gi, "פעם ביום"],
+  [/\bbid\b/gi, "פעמיים ביום"],
+  [/\btid\b/gi, "שלוש פעמים ביום"],
+  [/\bqid\b/gi, "ארבע פעמים ביום"],
+  [/\bprn\b/gi, "לפי הצורך"],
+  [/\bqhs\b/gi, "בלילה"],
+  [/\bstat\b/gi, "מיידי"],
+];
+
+function translateFrequency(line: string): string {
+  let out = line;
+  for (const [pattern, hebrew] of FREQUENCY_MAP) {
+    out = out.replace(pattern, hebrew);
+  }
+  return out;
+}
+
+// ─── Section builders ──────────────────────────────────────────────────
+
+function buildHeader(patient: PatientEntry): string[] {
+  const lines: string[] = [];
+  lines.push("# מטופל בקבלה");
+  const demographics: string[] = [];
+  if (patient.name) demographics.push(patient.name);
+  if (patient.age != null) demographics.push(`גיל ${patient.age}`);
+  if (patient.room) demographics.push(`חדר ${patient.room}`);
+  if (demographics.length > 0) lines.push(demographics.join(", "));
+  if (patient.date) lines.push(`תאריך קבלה: ${patient.date}`);
+  return lines;
+}
+
+function splitDiagnosisList(diagnosis: string | null | undefined): string[] {
+  if (!diagnosis) return [];
+  return diagnosis
+    .split(/[,;،/]|\s\+\s|\s\|\s/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function buildActiveDiagnoses(patient: PatientEntry): string[] {
+  const items = splitDiagnosisList(patient.diagnosis);
+  if (items.length === 0) return [];
+  const lines: string[] = ["# אבחנות פעילות"];
+  for (const item of items) {
+    lines.push(item.toUpperCase());
+  }
+  return lines;
+}
+
+function buildAllergies(patient: PatientEntry): string[] {
+  const allergies = patient.allergies ?? [];
+  if (allergies.length === 0) return ["# רגישויות", "לא ידוע על רגישות"];
+  return ["# רגישויות", ...allergies];
+}
+
+// ─── תפקוד (functional status) ────────────────────────────────────────
+
+const MOBILITY_LABEL: Record<string, string> = {
+  independent: "עצמאי",
+  walker: "הולך בעזרת הליכון",
+  wheelchair: "כיסא גלגלים",
+  bedbound: "מרותק למיטה",
+};
+
+const COGNITION_LABEL: Record<string, string> = {
+  oriented: "מתמצא",
+  mci: "ירידה קוגניטיבית קלה",
+  dementia: "דמנציה",
+  unknown: "לא ידוע",
+};
+
+const LIVING_LABEL: Record<string, string> = {
+  independent: "מתגורר בבית",
+  with_family: "מתגורר עם משפחה",
+  assisted_living: "דיור מוגן",
+  nursing_home: "בית אבות",
+};
+
+function buildFunctional(patient: PatientEntry): string[] {
+  const meta = patient.clinicalMeta ?? {};
+  const rows: Array<[string, string | undefined]> = [
+    ["מגורים", meta.livingArrangement ? LIVING_LABEL[meta.livingArrangement] : undefined],
+    ["ניידות", meta.baselineMobility ? MOBILITY_LABEL[meta.baselineMobility] : undefined],
+    ["התמצאות", meta.baselineCognition ? COGNITION_LABEL[meta.baselineCognition] : undefined],
+  ];
+  const filled = rows.filter((r): r is [string, string] => !!r[1]);
+  if (filled.length === 0) return [];
+  const lines: string[] = ["# תפקוד"];
+  for (const [label, value] of filled) {
+    lines.push(`${label}: ${value}`);
+  }
+  return lines;
+}
+
+// ─── Labs ──────────────────────────────────────────────────────────────
+
+function latestByLabel(labs: LabEntry[]): Map<string, LabEntry[]> {
+  const grouped = new Map<string, LabEntry[]>();
+  for (const l of labs) {
+    const arr = grouped.get(l.label) ?? [];
+    arr.push(l);
+    grouped.set(l.label, arr);
+  }
+  for (const [label, arr] of grouped) {
+    arr.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
+    grouped.set(label, arr);
+  }
+  return grouped;
+}
+
+const LAB_HE: Record<string, string> = {
+  Cr: "קריאטינין",
+  "K+": "אשלגן",
+  K: "אשלגן",
+  Na: "נתרן",
+  Hb: "המוגלובין",
+  WBC: "לויקוציטים",
+  PLT: "טסיות",
+  CRP: "CRP",
+  INR: "INR",
+  Lactate: "לקטט",
+  Glucose: "גלוקוז",
+  BUN: "BUN",
+  eGFR: "eGFR",
+};
+
+function formatNumber(n: number): string {
+  const rounded = Math.round(n * 100) / 100;
+  return Number.isInteger(rounded) ? rounded.toString() : rounded.toString();
+}
+
+function buildLabs(patient: PatientEntry): string[] {
+  const labs = patient.labs ?? [];
+  if (labs.length === 0) return [];
+  const grouped = latestByLabel(labs);
+  const lines: string[] = ["# מעבדה"];
+  for (const [label, entries] of grouped) {
+    const heLabel = LAB_HE[label] ?? label;
+    if (entries.length === 1) {
+      lines.push(`${heLabel}: ${formatNumber(entries[0].value)}`);
+    } else {
+      const previous = entries[entries.length - 2];
+      const latest = entries[entries.length - 1];
+      lines.push(`${heLabel}: ${formatNumber(previous.value)} > ${formatNumber(latest.value)}`);
+    }
+  }
+  return lines;
+}
+
+// ─── Medications ───────────────────────────────────────────────────────
+
+function buildMedications(patient: PatientEntry): string[] {
+  const meds = (patient.medications ?? []).filter((m) => m && m.trim().length > 0);
+  if (meds.length === 0) return [];
+  const lines: string[] = ["# תרופות בבית"];
+  meds.forEach((raw, i) => {
+    lines.push(`${i + 1}. ${translateFrequency(raw.trim())}`);
+  });
+  return lines;
+}
+
+// ─── Plan / Notes / Handover ──────────────────────────────────────────
+
+function buildPlan(patient: PatientEntry): string[] {
+  const tasks = patient.tasks.filter((t) => !t.done);
+  const planItems = patient.planNotes ?? [];
+  if (tasks.length === 0 && planItems.length === 0) return [];
+  const lines: string[] = ["# תוכנית"];
+  for (const t of tasks) lines.push(t.text);
+  for (const p of planItems) lines.push(p);
+  return lines;
+}
+
+function buildHandover(patient: PatientEntry): string[] {
+  if (!patient.handoverNote || !patient.handoverNote.trim()) return [];
+  return ["# הערת מסירה", patient.handoverNote.trim()];
+}
+
+// ─── Capacity flag ─────────────────────────────────────────────────────
+
+function buildCapacityFlag(patient: PatientEntry): string[] {
+  if (!patient.needsCapacityAssessment) return [];
+  return ["# הערה", "נדרשת הערכת כשירות לפי הנחיות משרד הבריאות"];
+}
+
+// ─── Entry point ───────────────────────────────────────────────────────
+
+export function generateChameleonRoundsNote(patient: PatientEntry): string {
+  const sections: string[][] = [
+    buildHeader(patient),
+    buildActiveDiagnoses(patient),
+    buildAllergies(patient),
+    buildFunctional(patient),
+    buildLabs(patient),
+    buildMedications(patient),
+    buildPlan(patient),
+    buildHandover(patient),
+    buildCapacityFlag(patient),
+  ];
+
+  return sections
+    .filter((s) => s.length > 0)
+    .map((s) => s.join("\n"))
+    .join("\n\n");
+}

--- a/src/types/patient.ts
+++ b/src/types/patient.ts
@@ -148,6 +148,12 @@ export type PatientEntry = {
   discharged?: boolean;
   isAdmission?: boolean;
 
+  // MOH surrogate-consent trigger: flagged by the intake processor when an
+  // elderly patient (age >= 65) has a high anticholinergic burden (ACB >= 3).
+  // UI surfaces this as a reminder to verify decision-making capacity before
+  // discharge planning or advance-directive discussions.
+  needsCapacityAssessment?: boolean;
+
   // Legacy photo attachments (base64 data URLs, stored in localStorage).
   // DEPRECATED: Phase 2 migration moves blobs to IndexedDB.
   // After migration this field is removed from the patient record.


### PR DESCRIPTION
## Summary

Adds an admission intake processor and a Chameleon EMR rounds-note synthesizer to automate clinical data entry and EMR export.

- **`src/engine/admissionProcessor.ts`** — `processIntake(raw)` hydrates the form payload, computes ACB + falls-risk baselines, enforces `isAdmission: true` and `generatedTasks: []` (Golden Rule: no auto-gen tasks on admission), stamps `scannedAt`, and sets `needsCapacityAssessment` when `age >= 65 && acb >= 3` for MOH surrogate-consent triggers.
- **`src/parser/chameleonExport.ts`** — `generateChameleonRoundsNote(patient)` produces a plain-text SZMC rounds note ready to paste into Chameleon EMR:
  - Plain `#` headers (no Markdown bold/asterisks)
  - Lab transitions as `prev > latest` with spaces (no Unicode arrows)
  - Active diagnoses in UPPERCASE English
  - Medications as a 1..N numbered list with Hebrew frequency translations (`q8h` → `כל 8 שעות`, `qd` → `פעם ביום`, `bid`/`tid`/`qid`/`prn`/`qhs`/`stat`)
- **`AddAdmissionModal.tsx`** — intercepts the form payload and runs it through `processIntake()` before dispatching `NEW_ADMISSION` (which preserves the existing admission-event logging + bed-conflict detection).
- **`PatientCardAlerts.tsx`** — adds a Tailwind-styled `העתק לסיכום ממוחשב` button that writes the Chameleon note via `navigator.clipboard.writeText` and briefly flashes a `✓ הועתק` success state.
- **`PatientEntry`** gains an optional `needsCapacityAssessment` boolean; `normalizePatient` preserves it across localStorage rehydration.

QuickCaptureSheet was reviewed — it dispatches `ADD_TASK` / `ADD_UNASSIGNED_TASK`, not an admission, so no intake routing is needed there.

## Verification

- `npx tsc --noEmit` — zero errors
- `npx vitest run` — **2207 / 2207 passing** (69 files)
- `npx vite build` — main bundle **145.39 kB** (under the 150 kB gate)

## Test plan

- [ ] Admit a 78 y/o on amitriptyline + oxybutynin → expect `needsCapacityAssessment: true` on the patient record and no generated tasks appearing in the card.
- [ ] Admit a 72 y/o on no anticholinergics → expect `needsCapacityAssessment: false` (or omitted) and `generatedTasks: []`.
- [ ] Click `📋 העתק לסיכום ממוחשב` on a patient with labs, meds, and active diagnoses → paste into a scratch doc and verify: plain `#` headers, lab transitions as `1.55 > 1.03`, diagnoses UPPERCASE English, meds numbered with Hebrew frequency.
- [ ] Click again — button shows `✓ הועתק` for ~1.5 s then reverts.
