### PR TITLE
chore: refresh CLAUDE.md currency drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Live: https://toranot.netlify.app
 
 ```bash
 npm run dev          # Dev server at http://localhost:5173/Toranot/
-npm test             # Run all tests (vitest, ~2,150 tests across 69 files)
+npm test             # Run all tests (vitest, ~2,150 tests across 73 files)
 npm run build        # TypeScript check + Vite build → dist/
 npm run typecheck    # tsc --noEmit (strict mode)
 ```
@@ -80,7 +80,7 @@ src/
 │   ├── AddAdmissionModal.tsx  # Admission workflow
 │   ├── OnCallProtocols.tsx    # IV/clinical protocol reference
 │   └── ...                    # 38+ more components (many lazy-loaded)
-└── __tests__/                 # 69 test files, ~2,150 tests
+└── __tests__/                 # 73 test files, ~2,150 tests
 
 netlify/functions/             # Serverless API proxies + ops helpers
 ├── claude.ts, gemini.ts, ocr-proxy.ts, github-pat.ts  # AI/auth proxies
@@ -91,7 +91,7 @@ public/
 ├── sw.js, manifest.json, iv-protocols.json, szmc-iv-protocols.json
 ```
 
-**Codebase size**: ~162 TypeScript/TSX files (~92 source + 69 test + 1 index).
+**Codebase size**: ~166 TypeScript/TSX files (~92 source + 73 test + 1 index).
 
 ## Architecture
 
@@ -113,7 +113,7 @@ All clinical logic in `src/engine/` — deterministic, pure functions, heavily t
 
 ## Testing
 
-**~2,150 tests across 69 files** — run `npm test` to see current count.
+**~2,150 tests across 73 files** — run `npm test` to see current count.
 
 Always run `npm test` before every push. ALL tests must pass.
 
@@ -202,7 +202,7 @@ UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN, API_SECRET
 | Metric | Value |
 |--------|-------|
 | Source files (TS/TSX) | ~92 |
-| Test files | 69 |
+| Test files | 73 |
 | Total tests | ~2,150 |
 | Components | 46 |
 | Engine modules | 13 |


### PR DESCRIPTION
- Quick Commands npm test comment said "69 files", now 73 (actual count of `src/__tests__/` test files)
- Project Structure `__tests__/` entry said "69 test files", now 73
- Testing section header said "~2,150 tests across 69 files", now 73 files
- Codebase size said "~162 TypeScript/TSX files (~92 source + 69 test + 1 index)", now ~166 files (~92 source + 73 test + 1 index)
- Codebase Metrics "Test files" said 69, now 73

Targeted refresh — no restructuring. Auto-generated by claude-md-drift-refresh routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcJNPekLNVNR1ukDMwkUNu)_