### PR TITLE
fix(rls-audit): Q1 allow-list public-schema only (drops false positives on supabase_migrations + topology)

### DIFF
--- a/.github/workflows/rls-audit.yml
+++ b/.github/workflows/rls-audit.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           curl -sf -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
                -H 'Content-Type: application/json' \
-               -d '{"query": "SELECT schemaname, tablename, rowsecurity FROM pg_tables WHERE schemaname NOT IN ('"'"'pg_catalog'"'"','"'"'information_schema'"'"','"'"'auth'"'"','"'"'storage'"'"','"'"'realtime'"'"','"'"'supabase_functions'"'"','"'"'extensions'"'"','"'"'vault'"'"','"'"'graphql'"'"','"'"'graphql_public'"'"','"'"'pgsodium'"'"','"'"'pgsodium_masks'"'"','"'"'net'"'"') ORDER BY rowsecurity ASC, schemaname, tablename;"}' \
+               -d '{"query": "SELECT schemaname, tablename, rowsecurity FROM pg_tables WHERE schemaname = '"'"'public'"'"' ORDER BY rowsecurity ASC, schemaname, tablename;"}' \
                "https://api.supabase.com/v1/projects/$PROJECT_ID/database/query" \
                > audit_logs/rls/$(date -u +%Y-%m-%d)-q1-rowsecurity.json
           if jq -e '.[] | select(.rowsecurity == false)' audit_logs/rls/$(date -u +%Y-%m-%d)-q1-rowsecurity.json > /tmp/holes.json; then


### PR DESCRIPTION
**The new RLS sanity cron from #83 caught a false positive on first manual run** (run #25209847672).

Q1 of the cron flagged 3 "RLS holes":
- `supabase_migrations.schema_migrations` — Supabase's own migration tracker (RLS off by design, service-role only)
- `topology.layer` and `topology.topology` — PostGIS topology extension internal tables (RLS off is the PostGIS standard)

None are user data. The Q1 NOT-IN exclusion list missed both schemas.

## Fix

Switch Q1 from exclusion-list (`WHERE schemaname NOT IN (...)`) to allow-list (`WHERE schemaname = 'public'`) — the same pattern Q2 already uses.

The step name was already "every public-schema table" — this just makes the query match the contract.

## Why allow-list > exclusion-list

- **Tighter:** can't accidentally include a new system schema added by future Supabase/extension upgrades.
- **No bit-rot:** the exclusion list would need to grow every time a new internal/extension schema is provisioned. The allow-list never needs maintenance.
- **Consistent:** Q2 already does it this way. Now Q1 matches.

After merge: re-trigger the workflow_dispatch, expect 5/5 ✓ on the resulting commit (which also doubles as confirmation the Supabase GitHub App is uninstalled — no `Supabase Preview` check on the new SHA).