### PR TITLE
fix(simulator): allow 3-6 option counts (was hardcoded === 4)

### DIFF
--- a/simulate_pwas.mjs
+++ b/simulate_pwas.mjs
@@ -111,17 +111,26 @@ async function simulate(repo) {
         const arr = JSON.parse(raw);
         log(repo.name, 'DATA', `questions.json: ${arr.length} questions`);
 
-        // Sanity-check: c must be valid index, c_accept must contain c if present
+        // Sanity-check: c must be valid index, c_accept must contain c if present.
+        // Option count: 2026-05-02 — relaxed from `!== 4` to a 3-6 range. The
+        // medical PWAs render variable-length options dynamically (q.o.forEach
+        // with Hebrew letters String.fromCharCode(1488+i) → א/ב/ג/ד/ה). The
+        // 4-option assumption broke when GRS8 questions (5 options each) were
+        // imported into Geri — the simulator was reporting them as bugs but
+        // they actually render fine. cInvalid catches the real problem
+        // (c-index out of range), so missingFields is now scoped to genuinely
+        // broken questions: missing fields, or option counts so far outside
+        // the medical-MCQ norm that something is structurally wrong.
         let cInvalid = 0, cAcceptMissingC = 0, missingFields = 0;
         for (let i = 0; i < arr.length; i++) {
           const q = arr[i];
           if (typeof q.c !== 'number' || q.c < 0 || q.c >= (q.o?.length ?? 0)) cInvalid++;
           if (Array.isArray(q.c_accept) && !q.c_accept.includes(q.c)) cAcceptMissingC++;
-          if (!q.q || !q.o || q.o.length !== 4) missingFields++;
+          if (!q.q || !q.o || !Array.isArray(q.o) || q.o.length < 3 || q.o.length > 6) missingFields++;
         }
-        if (cInvalid) log(repo.name, 'BUG', `${cInvalid} questions have invalid c index`);
+        if (cInvalid) log(repo.name, 'BUG', `${cInvalid} questions have invalid c index (out of options range)`);
         if (cAcceptMissingC) log(repo.name, 'BUG', `${cAcceptMissingC} questions: c not in c_accept (regression invariant violated)`);
-        if (missingFields) log(repo.name, 'BUG', `${missingFields} questions: missing q/o or wrong option count`);
+        if (missingFields) log(repo.name, 'BUG', `${missingFields} questions: missing q/o, or option count outside 3-6 range (structurally broken)`);
 
         // Find any questions where e contains "המפתח הרשמי" (the legacy artifact pattern)
         const artifactCount = arr.filter(q => (q.e || '').includes('המפתח הרשמי')).length;


### PR DESCRIPTION
Fixes false-positive BUG class in `simulate_pwas.mjs` (committed in PR #88). Hardcoded `q.o.length !== 4` flagged 38 of Geri's 3833 questions as broken — they're actually GRS8 imports (American 5-option format) that Geri's renderer handles correctly.

## What was wrong
`simulate_pwas.mjs:120`:
```js
if (!q.q || !q.o || q.o.length !== 4) missingFields++;
```

Reported "38 questions: missing q/o or wrong option count" → I escalated this in bug-hunt to "38 questions silently filtered at runtime". **Wrong.** Geri's renderer (`shlav-a-mega.html:1475, 2092, 2760, 2802`) iterates options dynamically with `q.o.forEach` and `% q.o.length`. Hebrew letter labels generated via `String.fromCharCode(1488+i)` cover up to ה (he) at index 4 = 5-option support. Line 2744 has explicit `letters=['A','B','C','D','E']`.

The 38 GRS8 questions DO reach users with all 5 options. The simulator was over-flagging.

## What's fixed
- Relax to 3-6 option range (medical MCQ norm)
- Sharpen the message: 'option count outside 3-6 range (structurally broken)' instead of generic 'wrong option count'
- The narrow `cInvalid` check (c-index out of options range) catches real shape problems

## Separate finding (NOT fixed in this PR)
Some of the 38 GRS8 questions have content-quality issues from import:
- Citation bleed in stems (e.g., `'ms with the management of asthma in the elderly. Clin Exp Allergy. 2011;41(4):471481.'`)
- Mid-sentence text truncation
- Non-grammatical concatenation

That's a Geri-side content-cleanup task on `data/questions.json`, not a simulator or render fix. Listed in this PR description so future bug hunts have the lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)