### PR TITLE
docs(claude): single-lane operating model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,20 @@
 # CLAUDE.md — Toranot (תורנות)
 
+## Operating model — single lane (from 2026-05-19)
+
+Development on this repo is done by Claude Code directly — design,
+implementation, testing, and shipping all in one session. This **supersedes**
+every "two-lane", "web-lane", or "terminal-lane" instruction in older docs and
+skills (audit-fix-deploy and the per-repo skills included): there is no second
+Claude lane, and no `claude/web-` vs `claude/term-` branch split.
+
+Workflow: branch `claude/<slug>` -> PR -> CI green + Codex review -> Eias
+merges -> post-merge `verify-deploy`. Codex is the independent automated
+reviewer. Eias is the sole merge authority — no self-merge. All release,
+version-trinity, and verification rules in the repo's skill still apply
+unchanged.
+
+
 <!-- working-rules-v1:start -->
 ## Working Rules (user-mandated, non-negotiable)
 


### PR DESCRIPTION
Propagates the single-lane operating-model note into this repo's CLAUDE.md (docs-only, idempotent, one paragraph). No code, version, or config changes.