### PR TITLE
fix(weekly-audit): read bundle size from dist/, not colored stdout

### DIFF
--- a/.github/workflows/toranot-weekly-audit.yml
+++ b/.github/workflows/toranot-weekly-audit.yml
@@ -37,7 +37,9 @@ jobs:
         run: |
           npx vite build
           # Main entry chunk is dist/assets/index-<hash>.js (Vite naming).
-          MAIN_JS=$(ls -1 dist/assets/index-*.js 2>/dev/null | head -1)
+          # `|| true` keeps the no-match case from tripping pipefail/set -e
+          # before the `if [ -z "$MAIN_JS" ]` diagnostic can run.
+          MAIN_JS=$(ls -1 dist/assets/index-*.js 2>/dev/null | head -1 || true)
           if [ -z "$MAIN_JS" ]; then
             echo "::error::No main entry chunk found in dist/assets/"
             ls -la dist/assets/ || true

--- a/.github/workflows/toranot-weekly-audit.yml
+++ b/.github/workflows/toranot-weekly-audit.yml
@@ -35,11 +35,20 @@ jobs:
       - name: Build and check bundle size
         id: build
         run: |
-          BUILD_OUT=$(npx vite build 2>&1)
-          echo "$BUILD_OUT"
-          SIZE=$(echo "$BUILD_OUT" | grep "dist/assets/index-" | grep "\.js " | grep -oP '[\d.]+\s*kB' | head -1 | grep -oP '[\d.]+')
+          npx vite build
+          # Main entry chunk is dist/assets/index-<hash>.js (Vite naming).
+          MAIN_JS=$(ls -1 dist/assets/index-*.js 2>/dev/null | head -1)
+          if [ -z "$MAIN_JS" ]; then
+            echo "::error::No main entry chunk found in dist/assets/"
+            ls -la dist/assets/ || true
+            exit 1
+          fi
+          # awk handles the float math without bc and is portable.
+          # Use decimal kB to match Vite's reported size (original 150 kB budget was set in decimal kB).
+          SIZE=$(awk -v b="$(stat -c%s "$MAIN_JS")" 'BEGIN{printf "%.2f", b/1000}')
+          echo "Main entry: $MAIN_JS = $SIZE kB"
           echo "bundle_size=$SIZE" >> $GITHUB_OUTPUT
-          if [ "$(echo "$SIZE > 150" | bc -l)" = "1" ]; then
+          if awk "BEGIN{exit !($SIZE > 150)}"; then
             echo "::error::Bundle size ${SIZE} kB exceeds 150 kB limit"
             exit 1
           fi


### PR DESCRIPTION
## Problem

**Toranot Weekly Audit** has been failing every Monday for 4 consecutive weeks (2026-04-27 → 2026-05-18) on the `Build and check bundle size` step.

## Root cause

GitHub Actions sets `FORCE_COLOR=1` by default. Vite v7 honors it and emits ANSI escape codes inside the size-summary lines, so `grep "dist/assets/index-"` no longer matches (the literal substring isn't contiguous in colored output). Combined with `pipefail` (GH Actions default), the failed grep propagates exit 1, `set -e` fires, and the step exits **before** the bc budget check even runs. The vite build itself succeeds — we never actually exceeded the budget.

## Reproduction

Verified locally with `FORCE_COLOR=1 npx vite build` piped through the old grep chain under `bash -eo pipefail`: exits 1, no budget breach. Without `FORCE_COLOR=1`, passes.

## Fix

Read the main-entry chunk size directly from the filesystem after build:

- `ls dist/assets/index-*.js | head -1` resolves the hashed main entry.
- `stat -c%s` + `awk` gives portable float math (drops `bc`).
- Decimal kB to match vite reporting so the **150 kB** budget keeps its original semantics.
- Hard error if no main entry exists (catches future build-output changes).

## Verification (pre-commit gate)

Local build of `main` HEAD: `dist/assets/index-BVH7Q9CA.js = 146.47 kB` — under budget. FORCE_COLOR=1 no longer affects the result.

## Scope

Workflow-only change. No app code, no proxy, no edge functions, no engine. Safe to self-merge once CI/Codex green per the captain-mode self-merge carve-out (not audit-evidence, not PHI, not CODEOWNERS-protected).
