### PR TITLE
chore(deps): npm audit fix — patch transitive ws moderate advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3647,9 +3647,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## What

`npm audit fix` (no `--force`) — bumps the transitive `ws` dependency to patch **GHSA-58qx-3vcg-4xpx** (uninitialized memory disclosure, moderate, CVSS 4.4).

## Scope

- `package-lock.json` only (3 insertions / 3 deletions — a single transitive version bump).
- Non-breaking: `fixAvailable: true` (no `--force`, no major bump).
- `npm audit` now reports **0 vulnerabilities** (was 1 moderate).

## Verify gate — green

- `npm run typecheck` (`tsc --noEmit`) — clean
- `npm test` — 2310 passed / 2 skipped
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)