### PR TITLE
fix(netlify): route /api/skill-snapshot to its function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -70,6 +70,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/skill-snapshot"
+  to = "/.netlify/functions/skill-snapshot"
+  status = 200
+
+[[redirects]]
   from = "/api/feedback-notify"
   to = "/.netlify/functions/feedback-notify"
   status = 200


### PR DESCRIPTION
## Summary
- Added missing `/api/skill-snapshot` → `/.netlify/functions/skill-snapshot` redirect to `netlify.toml`, parallel to the existing `/api/self-audit` rule.
- One-line additive change. No source code touched.

## Why
Live audit (via `/audit-fix-deploy` § B.1) found `GET /api/skill-snapshot` returns the SPA HTML fallback instead of JSON. The function itself exists, deploys, and works at `/.netlify/functions/skill-snapshot` (200 OK with valid JSON). Only the `/api/*` alias was never added.

The `audit-fix-deploy` SKILL.md documents the contract:
> `/api/skill-snapshot` and `/api/self-audit` return real `tokenUsage` field with `currentMonthTotals` + `allTimeTotals` (PR #79 contract).

`/api/self-audit` was wired correctly; `/api/skill-snapshot` was missed.

## Backward compatibility
Strictly additive. All known callers (`.claude/commands/toranot-*.md`, `IMPROVEMENTS.md`, the function's own header comment) use the direct `/.netlify/functions/skill-snapshot` path — those keep working unchanged.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 2310/2310 pass, 0 regressions
- [ ] After merge + Netlify deploy: `curl -sS https://toranot.netlify.app/api/skill-snapshot` returns JSON with `tokenUsage.currentMonthTotals`

## Out of scope (separate observation)
While probing, `/api/claude-legacy` also returns 404 despite having a redirect in `netlify.toml`. Root cause likely involves Netlify's edge-function-vs-redirect routing precedence and needs deeper investigation. Not currently impacting users (legacy is "emergency rollback only" per the toml comments) — left for a future PR.