### PR TITLE
fix(routing) + ci(smoke): remove dead /api/ocr-proxy + add live-endpoint probe

### DIFF
--- a/.github/workflows/netlify-deploy-monitor.yml
+++ b/.github/workflows/netlify-deploy-monitor.yml
@@ -18,6 +18,10 @@ jobs:
     name: Verify Netlify deploy reaches ready state
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Poll Netlify deploy status for this commit
         env:
           SITE_ID: 85d12386-b960-4f65-bee8-80e210ecd683
@@ -74,3 +78,10 @@ jobs:
           echo "::error::Timed out after $((MAX_ATTEMPTS * 20 + 30))s waiting for Netlify deploy of $GITHUB_SHA"
           echo "::error::Last observed state: ${STATE:-none}"
           exit 1
+      - name: Smoke-test live /api/* routes
+        # Runs only if the deploy poll above succeeded (default behavior).
+        # Probes every critical-path /api/* route and fails on 404/5xx —
+        # catches netlify.toml redirect drift that the deploy-state poll
+        # would not detect (a deploy can reach 'ready' even with broken
+        # redirects, as PR #98 surfaced for /api/skill-snapshot).
+        run: node scripts/smoke-test.cjs

--- a/netlify.toml
+++ b/netlify.toml
@@ -54,10 +54,14 @@
   to = "/.netlify/functions/ocr-proxy"
   status = 200
 
-[[redirects]]
-  from = "/api/ocr-proxy"
-  to = "/.netlify/functions/ocr-proxy"
-  status = 200
+# Note: `/api/ocr-proxy` (the function's own name) was previously declared
+# here as a duplicate alias for `/api/ocr`, but Netlify's routing did not
+# fire that redirect at runtime — every request returned 404 SPA HTML even
+# though the parsed redirect rule was reported as valid in deploy checks.
+# The only client (`src/components/Scanner.tsx`) uses `/api/ocr`, so the
+# dead alias was removed in PR #100. If a need for a `/api/ocr-proxy`
+# alias resurfaces, investigate the Netlify routing edge case first
+# (a parallel issue affects `/api/claude-legacy` — surfaced for review).
 
 [[redirects]]
   from = "/api/github-pat"

--- a/scripts/smoke-test.cjs
+++ b/scripts/smoke-test.cjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * smoke-test.cjs — Post-deploy live-endpoint probe for Toranot.
+ *
+ * Usage:
+ *   node scripts/smoke-test.cjs [base-url]
+ *
+ * Default base-url is https://toranot.netlify.app. Pass an alternate origin
+ * (e.g. a Netlify deploy-preview URL) as the first arg.
+ *
+ * Exit codes:
+ *   0 — all critical-path /api/* routes are correctly wired (no 404, no 5xx).
+ *   1 — at least one route is broken, mis-routed, or misconfigured.
+ *
+ * What "correctly wired" means: the function responds with its own HTTP
+ * status (200 / 204 / 401 / 405 etc.) rather than the SPA catch-all HTML
+ * 200 or Netlify's branded 404 page. Returning 401 (auth gate) or 405
+ * (method gate) is HEALTHY — it proves the function was actually invoked.
+ *
+ * The script makes the smallest valid probe per route. Routes that accept
+ * GET get a GET; POST-only routes get an OPTIONS preflight (which every
+ * function handles before auth/method gating).
+ */
+
+const BASE = process.argv[2] || "https://toranot.netlify.app";
+
+/** @typedef {{
+ *    path: string,
+ *    method: 'GET' | 'OPTIONS' | 'POST',
+ *    okStatuses: number[],
+ *    okContentTypePrefix?: string,
+ *    note: string,
+ *  }} Probe */
+
+/** @type {Probe[]} */
+const PROBES = [
+  // Read endpoints — return JSON on GET, no auth required.
+  {
+    path: "/api/skill-snapshot",
+    method: "GET",
+    okStatuses: [200, 503],
+    okContentTypePrefix: "application/json",
+    note: "skill-snapshot read (503 acceptable when Supabase env missing on this site)",
+  },
+  {
+    path: "/api/self-audit",
+    method: "GET",
+    okStatuses: [200, 503],
+    okContentTypePrefix: "application/json",
+    note: "self-audit read (503 acceptable when Supabase env missing on this site)",
+  },
+
+  // POST endpoints — gate auth/method without us needing valid credentials.
+  // OPTIONS preflight is sufficient: every function returns 204 for OPTIONS
+  // BEFORE checking auth, so any non-404 response proves routing works.
+  {
+    path: "/api/claude",
+    method: "OPTIONS",
+    okStatuses: [200, 204],
+    note: "claude proxy CORS preflight (edge function)",
+  },
+  {
+    path: "/api/gemini",
+    method: "OPTIONS",
+    okStatuses: [200, 204],
+    note: "gemini proxy CORS preflight",
+  },
+  {
+    path: "/api/ocr",
+    method: "OPTIONS",
+    okStatuses: [200, 204],
+    note: "ocr proxy CORS preflight (alias for ocr-proxy)",
+  },
+  {
+    path: "/api/feedback-notify",
+    method: "OPTIONS",
+    okStatuses: [200, 204, 405],
+    note: "feedback-notify CORS preflight (405 acceptable if OPTIONS not whitelisted)",
+  },
+  {
+    path: "/api/github-pat",
+    method: "GET",
+    okStatuses: [401, 405],
+    note: "github-pat (401/405 both prove function was invoked; 404 = redirect missing)",
+  },
+];
+
+const RED = "[31m";
+const GREEN = "[32m";
+const YELLOW = "[33m";
+const DIM = "[2m";
+const RESET = "[0m";
+const useColor = process.stdout.isTTY || process.env.CI === "true";
+const c = (color, s) => (useColor ? `${color}${s}${RESET}` : s);
+
+async function probe(p) {
+  const url = `${BASE}${p.path}`;
+  let status;
+  let contentType = "";
+  let err = "";
+
+  try {
+    const res = await fetch(url, { method: p.method, redirect: "manual" });
+    status = res.status;
+    contentType = (res.headers.get("content-type") || "").split(";")[0].trim();
+    // Drain body so connection closes cleanly
+    await res.text().catch(() => {});
+  } catch (e) {
+    err = String(e?.message || e);
+  }
+
+  const statusOk = p.okStatuses.includes(status);
+  const ctOk = !p.okContentTypePrefix ||
+    contentType.startsWith(p.okContentTypePrefix);
+  const pass = !err && statusOk && ctOk;
+
+  return { ...p, url, status, contentType, err, pass, statusOk, ctOk };
+}
+
+async function main() {
+  console.log(`Toranot post-deploy smoke test`);
+  console.log(`Base URL: ${BASE}`);
+  console.log("");
+
+  const results = [];
+  for (const p of PROBES) {
+    const r = await probe(p);
+    results.push(r);
+
+    const tag = r.pass ? c(GREEN, "PASS") : c(RED, "FAIL");
+    const detail = r.err
+      ? c(RED, `network error: ${r.err}`)
+      : `${r.method} ${r.status}${r.contentType ? ` ${r.contentType}` : ""}`;
+    console.log(`  ${tag} ${p.path.padEnd(22)} ${detail}`);
+    if (!r.pass && !r.err) {
+      if (!r.statusOk) {
+        console.log(`       ${c(YELLOW, `expected status ∈ {${p.okStatuses.join(",")}}, got ${r.status}`)}`);
+      }
+      if (!r.ctOk) {
+        console.log(`       ${c(YELLOW, `expected content-type ${p.okContentTypePrefix}*, got ${r.contentType || "(none)"}`)}`);
+      }
+      if (r.status === 404 && r.contentType.startsWith("text/html")) {
+        console.log(`       ${c(YELLOW, "404 + HTML body = redirect rule missing in netlify.toml")}`);
+      }
+    }
+    console.log(`       ${c(DIM, p.note)}`);
+  }
+
+  const failed = results.filter((r) => !r.pass);
+  console.log("");
+  if (failed.length === 0) {
+    console.log(c(GREEN, `✓ All ${results.length} /api/* routes are correctly wired.`));
+    process.exit(0);
+  }
+  console.log(c(RED, `✗ ${failed.length} of ${results.length} routes are broken:`));
+  for (const r of failed) {
+    console.log(`    ${r.path}  →  ${r.err || `${r.status} ${r.contentType}`}`);
+  }
+  process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(c(RED, `FATAL: ${e?.stack || e}`));
+  process.exit(1);
+});

--- a/scripts/smoke-test.cjs
+++ b/scripts/smoke-test.cjs
@@ -32,6 +32,14 @@ const BASE = process.argv[2] || "https://toranot.netlify.app";
  *    note: string,
  *  }} Probe */
 
+// Universal sanity check: the SPA catch-all rewrite (`/* -> /index.html`) returns
+// `200 text/html` for unmatched paths. If ANY probe — even one accepting status
+// 200 — gets `text/html`, that's the SPA, not the function. Always a FAIL.
+// This is what makes the smoke test detect missing redirects in the first
+// place; without it a missing /api/<name> redirect would silently PASS for
+// every OPTIONS probe that accepts 200.
+const SPA_FALLBACK_CT = "text/html";
+
 /** @type {Probe[]} */
 const PROBES = [
   // Read endpoints — return JSON on GET, no auth required.
@@ -50,9 +58,12 @@ const PROBES = [
     note: "self-audit read (503 acceptable when Supabase env missing on this site)",
   },
 
-  // POST endpoints — gate auth/method without us needing valid credentials.
-  // OPTIONS preflight is sufficient: every function returns 204 for OPTIONS
-  // BEFORE checking auth, so any non-404 response proves routing works.
+  // POST endpoints — probe via OPTIONS preflight to avoid needing real credentials.
+  // Legitimate function OPTIONS responses are 204 with empty body (and thus no
+  // content-type header). A 200 with `text/html` means the SPA catch-all fired
+  // instead of the redirect — that's the routing failure mode we exist to catch
+  // (see Codex P1 on PR #100). The universal SPA-fallback guard in `probe()`
+  // rejects `text/html` for every route regardless of status.
   {
     path: "/api/claude",
     method: "OPTIONS",
@@ -78,10 +89,15 @@ const PROBES = [
     note: "feedback-notify CORS preflight (405 acceptable if OPTIONS not whitelisted)",
   },
   {
+    // github-pat: 401 / 405 prove function was reached; 503 is acceptable too
+    // because `checkAuth()` returns 503 when Supabase auth verification times
+    // out — routing is still correct, the auth service is just temporarily
+    // slow. Accepting 503 keeps the smoke test from going red on transient
+    // upstream issues unrelated to redirect drift (Codex P2 on PR #100).
     path: "/api/github-pat",
     method: "GET",
-    okStatuses: [401, 405],
-    note: "github-pat (401/405 both prove function was invoked; 404 = redirect missing)",
+    okStatuses: [401, 405, 503],
+    note: "github-pat (401/405 prove function was invoked; 503 = Supabase auth timeout, routing still healthy; 404 = redirect missing)",
   },
 ];
 
@@ -110,11 +126,17 @@ async function probe(p) {
   }
 
   const statusOk = p.okStatuses.includes(status);
-  const ctOk = !p.okContentTypePrefix ||
-    contentType.startsWith(p.okContentTypePrefix);
+  // SPA-fallback guard: text/html on a /api/* route always means the redirect
+  // didn't fire and Netlify served index.html via the catch-all. Always FAIL,
+  // overrides any okStatuses match. (Codex P1 on PR #100: without this, a
+  // missing redirect that returns 200 HTML would PASS OPTIONS probes.)
+  const isSpaFallback = contentType.startsWith(SPA_FALLBACK_CT);
+  const ctOk = !isSpaFallback && (
+    !p.okContentTypePrefix || contentType.startsWith(p.okContentTypePrefix)
+  );
   const pass = !err && statusOk && ctOk;
 
-  return { ...p, url, status, contentType, err, pass, statusOk, ctOk };
+  return { ...p, url, status, contentType, err, pass, statusOk, ctOk, isSpaFallback };
 }
 
 async function main() {
@@ -133,14 +155,15 @@ async function main() {
       : `${r.method} ${r.status}${r.contentType ? ` ${r.contentType}` : ""}`;
     console.log(`  ${tag} ${p.path.padEnd(22)} ${detail}`);
     if (!r.pass && !r.err) {
-      if (!r.statusOk) {
-        console.log(`       ${c(YELLOW, `expected status ∈ {${p.okStatuses.join(",")}}, got ${r.status}`)}`);
-      }
-      if (!r.ctOk) {
-        console.log(`       ${c(YELLOW, `expected content-type ${p.okContentTypePrefix}*, got ${r.contentType || "(none)"}`)}`);
-      }
-      if (r.status === 404 && r.contentType.startsWith("text/html")) {
-        console.log(`       ${c(YELLOW, "404 + HTML body = redirect rule missing in netlify.toml")}`);
+      if (r.isSpaFallback) {
+        console.log(`       ${c(YELLOW, `${r.status} ${SPA_FALLBACK_CT} = SPA catch-all fired; redirect for ${p.path} is not active in netlify.toml`)}`);
+      } else {
+        if (!r.statusOk) {
+          console.log(`       ${c(YELLOW, `expected status ∈ {${p.okStatuses.join(",")}}, got ${r.status}`)}`);
+        }
+        if (!r.ctOk) {
+          console.log(`       ${c(YELLOW, `expected content-type ${p.okContentTypePrefix}*, got ${r.contentType || "(none)"}`)}`);
+        }
       }
     }
     console.log(`       ${c(DIM, p.note)}`);


### PR DESCRIPTION
## Summary
- Removed the dead `/api/ocr-proxy` redirect from `netlify.toml` — declared but 404ing at runtime, zero clients (Scanner uses `/api/ocr`).
- Added `scripts/smoke-test.cjs` — post-deploy live-endpoint probe that catches routing drift the existing deploy-state poll misses.
- Wired the smoke test into `.github/workflows/netlify-deploy-monitor.yml` as a step that runs immediately after the deploy reaches `ready`.

## Why
PR #98 surfaced that `/api/skill-snapshot` had been 404'ing in production despite the function existing and the deploy reaching `ready` state — the Netlify deploy-state poll alone cannot detect routing drift. Deeper audit found a second 404 of the same class (`/api/ocr-proxy`) and a third (`/api/claude-legacy`) that's credential-adjacent and surfaced for review below.

## Routing audit results
Live probe of every declared `/api/*` route in `netlify.toml`:

| Route | Status | Notes |
|---|---|---|
| `/api/claude` | OK (204 OPTIONS, 401 POST no-auth) | Edge function |
| `/api/gemini` | OK (204 OPTIONS) | |
| `/api/ocr` | OK (204 OPTIONS) | |
| `/api/ocr-proxy` | **404 (broken)** | **Removed in this PR** — dead alias, zero clients |
| `/api/github-pat` | OK (401) | |
| `/api/self-audit` | OK (200 JSON) | |
| `/api/skill-snapshot` | OK (200 JSON) | Fixed in PR #98 |
| `/api/feedback-notify` | OK (405 acceptable) | |
| `/api/claude-legacy` | **404 (broken)** | **Surfaced for review — see below** |

## Surfaced for review — NOT auto-fixed
**`/api/claude-legacy`** (emergency-rollback alias) is also 404ing. Investigation shows:
- Direct path `/.netlify/functions/claude` works (200 GET).
- The toml redirect IS declared and parsed cleanly (deploy "Redirect rules" check passes).
- Both `/api/ocr-proxy` (fixed here) and `/api/claude-legacy` share the property that `from` collides with a function-name prefix — suggesting a Netlify edge-vs-redirect precedence bug.

The fix would be to rename `/api/claude-legacy` to something like `/api/claude-fallback` (avoiding the `/api/claude*` prefix collision) and update the comments in `netlify.toml`. **Skipped here** because `/api/claude` is credential-adjacent per the captain-mode scope guard. Eias to decide whether to ship a rename in a separate PR.

## Smoke test design
- Node 22 native `fetch`, zero dependencies.
- Distinguishes function-reached responses (200/204/401/405) from routing-missing responses (404 + `text/html` SPA fallback).
- Special-cases content-type for read endpoints (`application/json` required) and method-gated endpoints (OPTIONS preflight tolerated).
- Accepts an optional base-URL arg so it can be pointed at a deploy preview: `node scripts/smoke-test.cjs https://deploy-preview-X--toranot.netlify.app`.
- Exit code 0 on full pass, 1 on any failure — CI-native.

Local run against live (current main) shows 7/7 pass.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — **2310/2310 pass, 2 skipped** (baseline unchanged; this PR adds no source code)
- [x] Local smoke test against current live: 7/7 PASS
- [ ] After merge: the new Netlify Deploy Monitor workflow step runs the smoke test and confirms 7/7 pass against the freshly-deployed main

## Scope discipline
- Did not touch `/api/claude` or `/api/github-pat` (credential-adjacent).
- Did not touch any function logic.
- Did not bump dependencies.
- Did not touch RLS / Supabase.
- Smoke test is additive (new file + 4-line workflow step + 4-line redirect removal).

## Files
```
.github/workflows/netlify-deploy-monitor.yml | 11 +++++++
netlify.toml                                 | 12 +++++----
scripts/smoke-test.cjs                       | NEW (zero deps)
```