### PR TITLE
fix(db): drop duplicate proxy_rate_limits monotonic-count trigger

### DIFF
--- a/supabase/migrations/20260524080500_drop_duplicate_proxy_rate_limit_trigger.sql
+++ b/supabase/migrations/20260524080500_drop_duplicate_proxy_rate_limit_trigger.sql
@@ -1,0 +1,53 @@
+-- 2026-05-24 — drop duplicate proxy_rate_limits monotonic-count trigger.
+--
+-- Background
+-- ----------
+-- The 2026-05-23 RLS sanity audit (recorded in Geriatrics IMPROVEMENTS.md
+-- entry of the same date — see PR #271) discovered that the proxy_rate_limits
+-- table carries TWO BEFORE-UPDATE triggers enforcing the same monotonic-count
+-- invariant. Both reject NEW.count < OLD.count with the same
+-- check_violation ERRCODE — net effect of having both is identical to
+-- having only one.
+--
+-- Trigger A (KEEP) — documented in deploy-primitives § 3:
+--   name:        proxy_rate_limits_monotonic_count_trg
+--   function:    proxy_rate_limits_monotonic_count()
+--   search_path: 'pg_catalog, public'
+--   fires on:    BEFORE UPDATE (any column)
+--   error msg:   'proxy_rate_limits: count is monotonic per (device_id, date);
+--                 refusing decrement from <old> to <new>'
+--
+-- Trigger B (DROP) — undocumented, likely a re-deploy artifact:
+--   name:        trg_proxy_rate_limit_monotonic
+--   function:    enforce_proxy_rate_limit_monotonic()
+--   search_path: '' (empty)
+--   fires on:    BEFORE UPDATE OF count
+--   error msg:   'proxy_rate_limits.count cannot decrease (was <old>,
+--                 attempted <new>)'
+--
+-- Safety
+-- ------
+-- Pre-flight checks (recorded in Geriatrics IMPROVEMENTS.md 2026-05-24 entry):
+--   1. No other function or view in the database references
+--      enforce_proxy_rate_limit_monotonic (pg_proc + pg_views scan, empty).
+--   2. No application code in any of the 6 sibling PWA repos
+--      (watch-advisor2, Toranot, Geriatrics, InternalMedicine,
+--      FamilyMedicine, ward-helper) references either the trigger or
+--      function by name (recursive grep, 0 hits across all repos).
+--   3. The active audit-8 R1.5 long-probe firstfail artifacts
+--      (network log + console log, captured at min ~49 of the
+--      2026-05-24 run) show zero references to proxy_rate_limits,
+--      rate_limit, 429, or any of the trigger/function names — the
+--      bifurcation evidence is uncorrelated with the rate-limit machinery.
+--
+-- Behavioral effect of this migration:
+--   - The documented trigger continues to enforce the invariant
+--     unchanged.
+--   - Updates attempting to decrement `count` still fail with the
+--     check_violation ERRCODE, just with one error message instead of
+--     two-overlapping messages.
+--
+-- Idempotency: uses IF EXISTS so re-running is safe (and a no-op).
+
+DROP TRIGGER IF EXISTS trg_proxy_rate_limit_monotonic ON public.proxy_rate_limits;
+DROP FUNCTION IF EXISTS public.enforce_proxy_rate_limit_monotonic();


### PR DESCRIPTION
## Summary

Drops the undocumented duplicate `trg_proxy_rate_limit_monotonic` trigger + its function `enforce_proxy_rate_limit_monotonic()` on `public.proxy_rate_limits`. The documented `proxy_rate_limits_monotonic_count_trg` (per deploy-primitives § 3) continues to enforce the monotonic-count invariant.

## The duplicate

Both triggers reject `NEW.count < OLD.count` with the same `check_violation` ERRCODE — net effect of having both is identical to having only one.

| | KEEP | DROP |
|---|---|---|
| Trigger | `proxy_rate_limits_monotonic_count_trg` | `trg_proxy_rate_limit_monotonic` |
| Function | `proxy_rate_limits_monotonic_count()` | `enforce_proxy_rate_limit_monotonic()` |
| `search_path` | `pg_catalog, public` | `''` (empty) |
| Fires on | UPDATE (any column) | UPDATE OF count |
| Error msg | "count is monotonic per (device_id, date); refusing decrement…" | "count cannot decrease (was X, attempted Y)" |
| Status | documented in deploy-primitives § 3 | undocumented (likely re-deploy artifact) |

Both fire on count-decrement attempts; both raise the same effective error. Dropping the undocumented one removes redundancy without semantic change.

## Safety

Pre-flight checks before this migration was authored:

1. **pg_proc + pg_views scan**: no other function or view references `enforce_proxy_rate_limit_monotonic` (0 dependent objects).
2. **Cross-repo grep**: 0 hits for the trigger or function name across all 6 PWA repos (watch-advisor2, Toranot, Geriatrics, InternalMedicine, FamilyMedicine, ward-helper) in `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/`.html`/`.sql` files. No application code references it.
3. **Active audit-8 R1.5 long-probe artifacts**: net-log + console-log checked clean against active audit-8 bifurcation investigation (firstfail artifacts min ~49, probe still running to min 600). 0 hits for `proxy_rate_limits`, `rate_limit`, `429`, or any trigger/function name. The bifurcation evidence is uncorrelated with rate-limit machinery.

## Idempotency

Uses `IF EXISTS` on both `DROP TRIGGER` and `DROP FUNCTION`. Re-running the migration is a safe no-op.

## Application

This is a file-only commit. Toranot CI does NOT auto-apply migrations:
- `deploy.yml` runs Netlify deploys, no Supabase CLI
- `rls-audit.yml` is the weekly read-only audit (not an apply step)

User applies manually via Supabase dashboard or `supabase db push` when ready.

## Pre-flight (Toranot pipeline §B.2)

- `tsc --noEmit`: exit 0
- `vitest run`: 73 files / 2,310 passed / 2 skipped / 0 failed
- `vite build`: exit 0 (1.18s)

## Lane

P3 of the 2026-05-24 carryover handoff (P1 = audit-8 R1.5 probe still running, P2 = Geriatrics PR #272 merged, P3 = this PR). HALTING at PR-open per rule — awaiting your call on whether to apply via dashboard or `supabase db push`.

## Test plan

- [ ] CI green (only `validate` / smoke-test workflows fire on a migration-file-only commit)
- [ ] After merge: apply the migration via Supabase dashboard or CLI, then verify with:
  ```sql
  SELECT t.tgname FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
  WHERE c.relname = 'proxy_rate_limits' AND NOT t.tgisinternal;
  -- Expect: only proxy_rate_limits_monotonic_count_trg
  ```