### PR TITLE
fix(netlify): remove dead /api/claude-legacy alias

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,9 +11,10 @@
 
 # ── Edge Functions — Deno runtime, no 26s sync wall, native streaming ──
 # /api/claude is served by netlify/edge-functions/claude.ts. It supersedes
-# the old netlify/functions/claude.ts (kept for emergency rollback at the
-# /api/claude-legacy redirect below). The Edge Function declares `path` in
-# its config export, so no `[[edge_functions]]` block needed here.
+# the old netlify/functions/claude.ts (kept as the emergency-rollback
+# target, hit directly at /.netlify/functions/claude — no /api alias, see
+# rollback note below). The Edge Function declares `path` in its config
+# export, so no `[[edge_functions]]` block needed here.
 
 [functions."toranot-keepalive"]
   schedule = "0 6 */5 * *"
@@ -36,13 +37,15 @@
 # ── API rewrites — map /api/* to Netlify Functions ──
 # /api/claude is intentionally NOT redirected here — the Edge Function at
 # netlify/edge-functions/claude.ts owns that path via its config.path export.
-# /api/claude-legacy is an emergency-rollback alias that bypasses the edge
-# runtime and hits the original sync function directly. Useful when the
-# edge function has a regression but the sync function is known-good.
-[[redirects]]
-  from = "/api/claude-legacy"
-  to = "/.netlify/functions/claude"
-  status = 200
+#
+# Emergency-rollback path for the /api/claude edge function: hit
+# /.netlify/functions/claude directly (the original sync function is still
+# deployed and untouched by edge-function changes). There is no /api/*
+# alias for it — a previous /api/claude-legacy redirect was removed
+# because Netlify's routing engine silently 404'd it (the redirect's
+# /api/claude* prefix collided with the edge function's config.path
+# matcher; same routing-precedence bug class that killed /api/ocr-proxy
+# in PR #100).
 
 [[redirects]]
   from = "/api/gemini"
@@ -59,9 +62,11 @@
 # fire that redirect at runtime — every request returned 404 SPA HTML even
 # though the parsed redirect rule was reported as valid in deploy checks.
 # The only client (`src/components/Scanner.tsx`) uses `/api/ocr`, so the
-# dead alias was removed in PR #100. If a need for a `/api/ocr-proxy`
-# alias resurfaces, investigate the Netlify routing edge case first
-# (a parallel issue affects `/api/claude-legacy` — surfaced for review).
+# dead alias was removed in PR #100. Same routing-precedence bug class
+# also killed `/api/claude-legacy` (removed in the PR introducing this
+# comment). If a need for a function-name-matching `/api/*` alias
+# resurfaces, use a semantically-different slug or hit
+# `/.netlify/functions/<name>` directly.
 
 [[redirects]]
   from = "/api/github-pat"


### PR DESCRIPTION
## Summary

Delete the `/api/claude-legacy` redirect from `netlify.toml`. It was the "emergency rollback" alias for the `/api/claude` edge function, but it never actually worked — Netlify's routing engine silently 404'd it because the redirect's `/api/claude*` prefix collided with the edge function's `config.path` matcher and the edge function consumed the request first. Same routing-precedence bug class that killed `/api/ocr-proxy` in #100 (see `project-netlify-redirect-silent-404-pattern` in session memory).

Eias picked **option (b)** from the previous session's surfaced decision: delete the broken alias, accept that the rollback path is `/.netlify/functions/claude` direct (verified working), document the bug class in the toml comments.

## Changes

- Remove the `[[redirects]]` block for `/api/claude-legacy`.
- Update the Edge-Function header comment block (lines 12–17) to point rollbackers at `/.netlify/functions/claude` direct.
- Update the API-rewrites header comment to document why no `/api/*` alias for the rollback path exists.
- Extend the existing `/api/ocr-proxy` postmortem comment to mention this is the same bug class.

## What this PR does NOT change

- No source code — `grep -r claude-legacy src/` returns zero matches; the alias had no callers.
- No smoke test probes — `scripts/smoke-test.cjs` never probed `/api/claude-legacy`, so the probe set is unchanged.
- No edge function or function logic.
- No `/api/claude` semantics (which is on tonight's NOT-pre-authorized list — this PR only touches the now-defunct alias).

## Follow-up surfaced (not in this PR)

`.claude/commands/toranot-audit-fix-deploy.md:505` still claims `/api/claude-legacy` is the rollback target. That file is agent config and out of scope for tonight's pre-auth (which covered `netlify.toml`, not `.claude/`). One-line doc-PR can clean it up later.

## Verify after merge

- `node scripts/smoke-test.cjs` (live, post-deploy) — should still pass all 7 probes. No `/api/claude-legacy` probe expected.
- Spot-check: `curl -i -X OPTIONS https://toranot.netlify.app/api/claude` should still return 204 (edge function untouched).

## Test plan

- [x] `grep -r claude-legacy src/` → zero hits
- [x] Local diff inspected — only `netlify.toml` touched
- [ ] CI green (vitest, build, deploy)
- [ ] Codex review
- [ ] Post-deploy smoke test PASS (workflow-driven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)