### PR TITLE
chore(docs): drop stale /api/claude-legacy ref (closed in #103)

### DIFF
--- a/.claude/commands/toranot-audit-fix-deploy.md
+++ b/.claude/commands/toranot-audit-fix-deploy.md
@@ -502,5 +502,8 @@ Then run `/toranot-update-skill` to verify self-consistency.
 - Never push direct to main — branch + PR + Codex review per single-lane CLAUDE.md
 - Test count must be verified after every change — ~2,310 is the baseline
 - The dual `netlify/functions/claude.ts` + `netlify/edge-functions/claude.ts` is
-  INTENTIONAL (functions version is the `/api/claude-legacy` emergency-rollback
-  target per `netlify.toml`). Audit grep checks must not flag it as duplication.
+  INTENTIONAL (functions version is the emergency-rollback target, hit directly
+  at `/.netlify/functions/claude` per `netlify.toml` comments). The previous
+  `/api/claude-legacy` alias was removed in PR #103 — the `/api/claude*` prefix
+  collided with the edge function's `config.path` and silently 404'd. Audit
+  grep checks must not flag the dual files as duplication.


### PR DESCRIPTION
## Summary
- Doc-only fix to `.claude/commands/toranot-audit-fix-deploy.md` HARD CONSTRAINTS line 504.
- The bullet about the dual `netlify/functions/claude.ts` + `netlify/edge-functions/claude.ts` was still pointing at `/api/claude-legacy` as the rollback URL — but that alias was deleted in PR #103 (`/api/claude*` prefix collision with the edge function's `config.path`, silent 404).
- Corrected to the current rollback URL: `/.netlify/functions/claude` direct. Added a one-sentence PR #103 provenance pointer so the next audit has the context.

## Carryover
Surfaced during the 2026-05-24 captain-mode session (PRs #98–#101 + memory note in `project-netlify-redirect-silent-404-pattern`). PR #103 took option (b) of the 3 surfaced — delete the alias entirely rather than rename — leaving this one stale doc reference that the audit-fix-deploy skill would have re-surfaced on the next run.

## Test plan
- [x] Doc-only — zero source / `netlify.toml` / test changes
- [ ] After merge: `node scripts/smoke-test.cjs` against live → 7/7 PASS (belt-and-braces)

## Scope
Skill doc, pre-authorized for D.5 self-merge per captain-mode session.