### PR TITLE
chore(rollback): self-documenting header comments on dual claude.ts files

### DIFF
--- a/netlify/edge-functions/claude.ts
+++ b/netlify/edge-functions/claude.ts
@@ -1,4 +1,11 @@
 /**
+ * ROLLBACK PAIR — DO NOT DELETE in isolation.
+ * This file is the edge-function half of the /api/claude rollback architecture.
+ * Standard-function half: netlify/functions/claude.ts
+ * See PR #103 (silent-404 routing fix) and audit-fix-deploy SKILL.md HARD CONSTRAINTS section.
+ * Deleting one without rotating the other breaks the rollback path.
+ */
+/**
  * Claude proxy — Netlify Edge Function (Deno runtime).
  *
  * Replaces the synchronous Netlify Function at `/api/claude` (which lives at

--- a/netlify/functions/claude.ts
+++ b/netlify/functions/claude.ts
@@ -1,3 +1,10 @@
+/**
+ * ROLLBACK PAIR — DO NOT DELETE in isolation.
+ * This file is the standard-function half of the /api/claude rollback architecture.
+ * Edge-function half: netlify/edge-functions/claude.ts
+ * See PR #103 (silent-404 routing fix) and audit-fix-deploy SKILL.md HARD CONSTRAINTS section.
+ * Deleting one without rotating the other breaks the rollback path.
+ */
 import type { Context, Config } from "@netlify/functions";
 import {
   checkAuth,


### PR DESCRIPTION
Comment-only edit. Codifies the invariant that netlify/functions/claude.ts and netlify/edge-functions/claude.ts are a load-bearing rollback pair, not redundant debris. Surfaces the architecture at the file level so a future grep-and-clean pass doesn't break the rollback path. Provenance: closes a docs-layer gap from PR #103 (silent-404 fix) and PR #104 (skill doc URL correction). Zero logic change, zero test impact.