### PR TITLE
fix(a11y): resolve all Lighthouse violations — 96/100 → 100/100

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -392,7 +392,7 @@ function BottomNav({
       <button
         onClick={() => onAction("handoff")}
         className="flex-1 flex flex-col items-center justify-center gap-0.5 min-h-[56px] text-slate-300 active:bg-slate-700 transition-colors"
-        aria-label="מסירת משמרת"
+        aria-label="מסירה — מסירת משמרת"
       >
         <span className="text-xl leading-none">📤</span>
         <span className="text-[10px] text-slate-400">מסירה</span>

--- a/src/components/OverflowMenu.tsx
+++ b/src/components/OverflowMenu.tsx
@@ -193,7 +193,7 @@ export function OverflowMenu({ onOpenModal }: { onOpenModal: (m: OverflowModal) 
         <button
           onClick={() => setOpen((v) => !v)}
           className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-slate-200 active:bg-slate-700 transition-colors text-lg"
-          aria-label="תפריט נוסף"
+          aria-label="··· — תפריט נוסף"
         >
           ···
         </button>

--- a/src/components/PatientList.tsx
+++ b/src/components/PatientList.tsx
@@ -146,7 +146,7 @@ export function PatientList() {
         <p className="text-sm mt-2 text-center leading-relaxed">
           צלמו דף תורן או הדביקו רשימה למעלה
           <br />
-          <span className="text-xs opacity-60">ניתן גם לגרור חולים מקטגוריה אחרת</span>
+          <span className="text-xs">ניתן גם לגרור חולים מקטגוריה אחרת</span>
         </p>
       </div>
     );


### PR DESCRIPTION
## Lighthouse-verified end to end

Baseline (deployed `toranot.netlify.app`): **96/100**, 3 failed audits, 4 violation nodes.
Local Chrome-headless mobile-emulation Lighthouse on built `dist/`: **100/100**, 0 failed audits.

This brings the 4th major Eiasash app to a11y 100/100, matching FM, IM, and Geri.

## Three surgical fixes

### Fix 1 — `label-content-name-mismatch` (OverflowMenu)
`src/components/OverflowMenu.tsx:196` — `<button aria-label="תפריט נוסף">···</button>`. Visible glyph `···` was not contained in the accessible name, violating WCAG 2.5.3 Label in Name (voice-control software cannot use visible text to address the button).

```diff
- aria-label="תפריט נוסף"
+ aria-label="··· — תפריט נוסף"
```

### Fix 2 — `label-content-name-mismatch` (handoff nav button)
`src/App.tsx:395` — visible `📤 מסירה`, aria-label `מסירת משמרת`. Visible `מסירה` not in aria-label (final letter differs: ה vs ת).

```diff
- aria-label="מסירת משמרת"
+ aria-label="מסירה — מסירת משמרת"
```

### Fix 3 — `color-contrast` (PatientList empty-state hint)
`src/components/PatientList.tsx:149` — `<span className="text-xs opacity-60">`. Parent text color `text-gray-500` (#6b7280, ~4.5:1 on white) plus `opacity-60` blended to **~2.7:1** — fail WCAG SC 1.4.3.

```diff
- <span className="text-xs opacity-60">ניתן גם לגרור חולים מקטגוריה אחרת</span>
+ <span className="text-xs">ניתן גם לגרור חולים מקטגוריה אחרת</span>
```

The `text-xs` size still visually de-emphasizes without breaking contrast.

## Verification

- Tests: **2310 passed / 2 skipped**
- Build: green
- Lighthouse on locally-built dist: **100/100 accessibility, 0 violations**

Pending live re-baseline post-deploy.