### PR TITLE
perf(sw): don't reload on first SW install — perf 88 → ~100 expected

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,22 +30,27 @@ const UPDATE_EVERY_MS = 5 * 60 * 1000;
 export function registerAndAutoUpdateSW() {
   if (!("serviceWorker" in navigator)) return;
 
-  // Capture whether a SW was already controlling the page BEFORE registration.
-  // The controllerchange event fires for BOTH first-install (no controller →
-  // new controller) and updates (old controller → new controller). Reloading
-  // on first-install is incorrect: the SW just gained control of a fresh
-  // page, there's nothing to refresh. Lighthouse counts the first-install
-  // reload as a page redirect, costing ~2.6s LCP on every first visit and
-  // dropping the perf score from ~100 → 88. Update-flow reload is preserved.
-  const hadControllerAtBoot = !!navigator.serviceWorker.controller;
-
+  // If the tab boots with no controller, the FIRST controllerchange we'll
+  // see is the SW gaining control of this page — a first install, no reload
+  // needed (page already rendered correctly from network). But for the same
+  // long-lived tab, a LATER controllerchange comes from a real update
+  // (5-min reg.update() / SKIP_WAITING flow) and DOES need a reload so the
+  // user picks up the new bundle.
+  //
+  // Track this as a one-shot "skip" flag — consume on the first
+  // controllerchange and let every subsequent one reload as before. Codex
+  // P2 on #107 caught the earlier "stays false forever" version which
+  // regressed the update path for any session that first-installed in the
+  // same tab.
+  let pendingFirstInstallSkip = !navigator.serviceWorker.controller;
   let refreshing = false;
 
   navigator.serviceWorker.addEventListener("controllerchange", () => {
+    if (pendingFirstInstallSkip) {
+      pendingFirstInstallSkip = false; // consume — first install handled, future events reload
+      return;
+    }
     if (refreshing) return;
-    // First-install path: SW now controls the page but no reload needed.
-    // The page was loaded fresh and rendered correctly from network.
-    if (!hadControllerAtBoot) return;
     refreshing = true;
     window.location.reload();
   });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,10 +30,22 @@ const UPDATE_EVERY_MS = 5 * 60 * 1000;
 export function registerAndAutoUpdateSW() {
   if (!("serviceWorker" in navigator)) return;
 
+  // Capture whether a SW was already controlling the page BEFORE registration.
+  // The controllerchange event fires for BOTH first-install (no controller →
+  // new controller) and updates (old controller → new controller). Reloading
+  // on first-install is incorrect: the SW just gained control of a fresh
+  // page, there's nothing to refresh. Lighthouse counts the first-install
+  // reload as a page redirect, costing ~2.6s LCP on every first visit and
+  // dropping the perf score from ~100 → 88. Update-flow reload is preserved.
+  const hadControllerAtBoot = !!navigator.serviceWorker.controller;
+
   let refreshing = false;
 
   navigator.serviceWorker.addEventListener("controllerchange", () => {
     if (refreshing) return;
+    // First-install path: SW now controls the page but no reload needed.
+    // The page was loaded fresh and rendered correctly from network.
+    if (!hadControllerAtBoot) return;
     refreshing = true;
     window.location.reload();
   });


### PR DESCRIPTION
## Top Lighthouse opportunity

`Avoid multiple page redirects` — Est savings of **2,610ms** on Toranot. This is the single biggest reason Toranot perf currently sits at 88/100 instead of 100.

## Root cause

`src/main.tsx` `registerAndAutoUpdateSW()` reloads on every `controllerchange` event:

```js
navigator.serviceWorker.addEventListener("controllerchange", () => {
  if (refreshing) return;
  refreshing = true;
  window.location.reload();
});
```

But `controllerchange` fires in **two** scenarios:
1. **First install**: no controller → new controller (just installed)
2. **Update**: old controller → new controller (after `SKIP_WAITING`)

The intent was (2). The handler also fires on (1) — and on a fresh first visit, that triggers an unnecessary full page reload. Lighthouse counts the first-install reload as a page redirect: **~2.6s LCP cost on every fresh visit**. Affects every new user.

## Fix

Capture whether a SW was already controlling the page BEFORE registration. Reload only if there was a previous controller (i.e., this is an update).

```diff
+ const hadControllerAtBoot = !!navigator.serviceWorker.controller;
  // ...
  navigator.serviceWorker.addEventListener("controllerchange", () => {
    if (refreshing) return;
+   if (!hadControllerAtBoot) return;  // first install — no reload needed
    refreshing = true;
    window.location.reload();
  });
```

Update flow unchanged: when a new SW activates over an existing one, `hadControllerAtBoot` is `true` → reload still happens → user gets new code.

## Verification

- Tests: **2310 passed**
- Build: green
- Expected: Lighthouse perf **88 → ~100** post-deploy (redirects audit drops from 2610ms wasted → 0)

## Sibling

wa2 Lighthouse showed 3240ms on the same audit — same bug class. Sibling PR after this lands.