### PR TITLE
chore: gitignore ad-hoc command-output logs (*_out.log)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist
 .env.local
 .env.*.local
 coverage/
+
+# Ad-hoc command-output redirects (e.g. `npm run build > build_out.log`)
+*_out.log


### PR DESCRIPTION
Adds `*_out.log` to `.gitignore` so manual output redirects (`build_out.log`, `vitest_out.log`) stop appearing as untracked clutter. The two leftover files were already cleared locally. Gitignore-only — no source/test/build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)