### PR TITLE
fix(phi): scrub error reports before they reach Supabase

### DIFF
--- a/src/__tests__/errorReporter.test.ts
+++ b/src/__tests__/errorReporter.test.ts
@@ -51,6 +51,23 @@ describe("scrubPayload", () => {
     expect(json).not.toMatch(/[֐-׿]/); // values scrubbed
     expect(json).not.toContain("99999");
   });
+
+  it("recurses into nested objects/arrays + redacts large numeric ids, keeping code locations (Codex P2)", () => {
+    const out = scrubPayload({
+      patient: { name: "כהן", id: 312345678 },
+      ids: [987654321, 12],
+      lineno: 4242, // code location — kept even though >= 1000
+      count: 7, // small number — kept
+    });
+    const json = JSON.stringify(out);
+    expect(json).not.toMatch(/[֐-׿]/); // nested Hebrew scrubbed
+    expect(json).not.toContain("312345678"); // nested numeric id redacted
+    expect(json).not.toContain("987654321"); // array numeric id redacted
+    expect(json).toContain("patient"); // keys preserved
+    expect(out.lineno).toBe(4242);
+    expect((out.patient as Record<string, unknown>).name).toBe("[he]");
+    expect((out.ids as unknown[])[1]).toBe(12);
+  });
 });
 
 describe("reportError → Supabase POST is PHI-scrubbed (message AND payload)", () => {

--- a/src/__tests__/errorReporter.test.ts
+++ b/src/__tests__/errorReporter.test.ts
@@ -1,0 +1,81 @@
+/**
+ * errorReporter PHI-scrub tests.
+ *
+ * errorReporter POSTs unhandled errors to Supabase (toranot_errors). In a
+ * patient-data app the message/stack can echo PHI, so it must be scrubbed
+ * BEFORE the POST. The integration test asserts that end-to-end through the
+ * fetch body — message AND payload.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://fake.supabase.co");
+vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+
+const fetchMock = vi.fn((_url: string, _init?: RequestInit) => Promise.resolve({} as Response));
+vi.stubGlobal("fetch", fetchMock);
+
+import { scrubPhi, cleanStack, scrubPayload, reportError } from "../utils/errorReporter";
+
+describe("scrubPhi", () => {
+  it("redacts digit runs >= 4, quoted echoes, and Hebrew; keeps short numbers + English", () => {
+    expect(scrubPhi("id 312345678 phone 0501234567")).toBe("id [#] phone [#]");
+    expect(scrubPhi("age 84 glucose 250")).toBe("age 84 glucose 250");
+    expect(scrubPhi('near "chest pain"')).toBe('near "[redacted]"');
+    expect(scrubPhi("המטופל כהן")).toContain("[he]");
+    expect(scrubPhi("המטופל כהן")).not.toMatch(/[֐-׿]/);
+    expect(scrubPhi("TypeError: x is not a function")).toBe("TypeError: x is not a function");
+  });
+});
+
+describe("cleanStack", () => {
+  it("drops the 'Error: <message>' header (which echoes raw PHI), keeps frames", () => {
+    const stack = "Error: secret חולה 312345678\n    at foo (app.js:10:5)\n    at bar (app.js:20:3)";
+    const out = cleanStack(stack);
+    expect(out).not.toContain("312345678");
+    expect(out).not.toMatch(/[֐-׿]/);
+    expect(out).toContain("at foo (app.js:10:5)");
+  });
+});
+
+describe("scrubPayload", () => {
+  it("scrubs string values (stack header dropped) but keeps keys + numbers", () => {
+    const out = scrubPayload({
+      stack: "Error: x 99999\n    at f (a.js:1:2)",
+      note: "חולה כהן",
+      lineno: 42,
+    });
+    expect(out.lineno).toBe(42); // numbers untouched
+    const json = JSON.stringify(out);
+    expect(json).toContain("stack"); // keys NOT redacted
+    expect(json).toContain("note");
+    expect(json).not.toMatch(/[֐-׿]/); // values scrubbed
+    expect(json).not.toContain("99999");
+  });
+});
+
+describe("reportError → Supabase POST is PHI-scrubbed (message AND payload)", () => {
+  it("a thrown Error with PHI leaks neither Hebrew nor the id into the POST body", () => {
+    fetchMock.mockClear();
+    const err = new Error("failed for חולה 312345678");
+    reportError("window.onerror", err.message, {
+      stack: err.stack,
+      filename: "app.js",
+      lineno: 42,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]![1]!;
+    const body = JSON.parse(String(init.body)) as { message: string; payload: string };
+
+    // message: scrubbed
+    expect(body.message).not.toMatch(/[֐-׿]/);
+    expect(body.message).not.toContain("312345678");
+
+    // payload (serialized): scrubbed — incl. the stack header that echoes the message
+    expect(body.payload).not.toMatch(/[֐-׿]/);
+    expect(body.payload).not.toContain("312345678");
+    // keys survive (we scrubbed fields, not the JSON string)
+    expect(body.payload).toContain("stack");
+    expect(body.payload).toContain("filename");
+  });
+});

--- a/src/utils/errorReporter.ts
+++ b/src/utils/errorReporter.ts
@@ -40,14 +40,34 @@ export function cleanStack(stack: string): string {
   return (start >= 0 ? lines.slice(start) : []).slice(0, 6).join("\n");
 }
 
-/** Scrub each field individually — NOT the serialized JSON (that would redact the keys too). */
-export function scrubPayload(payload: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(payload)) {
-    if (typeof v === "string") out[k] = k === "stack" ? cleanStack(v) : scrubPhi(v);
-    else out[k] = v; // numbers (lineno / colno) etc. — no PHI
+// Code-location fields are not PHI even when the number is large.
+const LOCATION_KEYS = new Set(["lineno", "colno", "line", "col", "lineNumber", "columnNumber"]);
+
+function scrubValue(key: string, v: unknown): unknown {
+  if (typeof v === "string") return key === "stack" ? cleanStack(v) : scrubPhi(v);
+  if (typeof v === "number") {
+    if (LOCATION_KEYS.has(key)) return v; // code location, not PHI
+    return Math.abs(v) >= 1000 ? "[#]" : v; // large numbers may be teudat-zehut / MRN / phone
   }
+  if (Array.isArray(v)) return v.map((item) => scrubValue(key, item));
+  if (v && typeof v === "object") return scrubObject(v as Record<string, unknown>);
+  return v; // boolean / null / undefined
+}
+
+function scrubObject(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) out[k] = scrubValue(k, v);
   return out;
+}
+
+/**
+ * Scrub each field individually — NOT the serialized JSON (that would redact the keys too) —
+ * recursing through nested objects/arrays so PHI inside `reportError`'s `Record<string, unknown>`
+ * payload can't slip through. Strings -> scrubPhi (stack -> cleanStack); numbers >= 1000 -> [#]
+ * except code-location fields (lineno/colno).
+ */
+export function scrubPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  return scrubObject(payload);
 }
 
 function getSupabaseConfig(): { url: string; key: string } | null {

--- a/src/utils/errorReporter.ts
+++ b/src/utils/errorReporter.ts
@@ -14,6 +14,42 @@
 const MAX_REPORTS_PER_SESSION = 5;
 let reportCount = 0;
 
+// --- PHI scrub (mirrors ward-helper's src/debug/console.ts) ------------------
+// These error reports are PERSISTED to Supabase (toranot_errors). In a patient-
+// data app an error message or stack can echo a name / id, so scrub before the
+// POST — never after. Keep code locations; redact the PHI shapes.
+
+/** Redact the three highest-risk PHI shapes; keep English error text readable. */
+export function scrubPhi(input: unknown): string {
+  const s = input == null ? "" : String(input);
+  return s
+    .replace(/\d{4,}/g, "[#]") // teudat-zehut / MRN / phone / dates / big labs
+    .replace(/"[^"]{0,400}"/g, '"[redacted]"') // quoted input echo
+    .replace(/'[^']{0,400}'/g, "'[redacted]'")
+    .replace(/[֐-׿]+(?:[\s.,:;()/\-]+[֐-׿]+)*/g, "[he]"); // any Hebrew run
+}
+
+/**
+ * Keep only real stack frames, dropping the leading "Error: <message>" header —
+ * that header echoes the RAW message, which the message-scrub alone would miss.
+ * Frames (`at fn (file:line:col)`) carry no PHI, so line/col are preserved.
+ */
+export function cleanStack(stack: string): string {
+  const lines = stack.split("\n");
+  const start = lines.findIndex((l) => /^\s*at\s/.test(l) || /@.+:\d+/.test(l));
+  return (start >= 0 ? lines.slice(start) : []).slice(0, 6).join("\n");
+}
+
+/** Scrub each field individually — NOT the serialized JSON (that would redact the keys too). */
+export function scrubPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(payload)) {
+    if (typeof v === "string") out[k] = k === "stack" ? cleanStack(v) : scrubPhi(v);
+    else out[k] = v; // numbers (lineno / colno) etc. — no PHI
+  }
+  return out;
+}
+
 function getSupabaseConfig(): { url: string; key: string } | null {
   try {
     const url = import.meta.env.VITE_SUPABASE_URL;
@@ -35,8 +71,8 @@ function sendError(level: "error" | "warn", source: string, message: string, pay
   const body = {
     level,
     source,
-    message: message.slice(0, 500), // truncate long messages
-    payload: payload ? JSON.stringify(payload).slice(0, 2000) : null,
+    message: scrubPhi(message).slice(0, 500), // PHI-scrub, then truncate
+    payload: payload ? JSON.stringify(scrubPayload(payload)).slice(0, 2000) : null,
     created_at: new Date().toISOString(),
   };
 


### PR DESCRIPTION
## Why

`src/utils/errorReporter.ts` POSTs unhandled errors (`window.error` + `unhandledrejection` + manual `reportError`) to the Supabase `toranot_errors` table — **fire-and-forget, previously unscrubbed**. This is a patient-data app: an error message or stack can echo a name / id, so those rows could hold PHI. Surfaced while auditing in-app error capture across the suite.

## What

Scrub **before** the POST (never after):

- `message` → `scrubPhi` — digit runs ≥4 → `[#]`, quoted echoes → `"[redacted]"`, any Hebrew run → `[he]`.
- `payload` → `scrubPayload` — each field scrubbed **individually before `JSON.stringify`** (scrubbing the serialized JSON would redact the *keys* too). `stack` → `cleanStack`, which **drops the `Error: <message>` header** — that header echoes the raw message and is the leak a message-only scrub misses. `filename`/`lineno`/`colno` kept (no PHI).

Same scrub logic as ward-helper's new error console (PR #233), mirrored here.

## Tests

`src/__tests__/errorReporter.test.ts` — 4 cases: `scrubPhi` / `cleanStack` (header drop) / `scrubPayload` (keys + numbers survive, values scrubbed) units, plus an **end-to-end assertion** that a thrown `Error('… <hebrew> 312345678')` leaks neither Hebrew nor the id into the POST body's `message` **or** `payload`.

## Verification

- `npm run typecheck` ✓ · `npm test` 74 files / 2314 pass (+4 mine, no regressions) ✓ · `npm run build` ✓
- No version bump: package.json version isn't enforced/displayed and isn't bumped per-PR here; the SW `CACHE_VERSION` auto-stamps `Date.now()` at build, so the deploy cache-busts on its own.

## Follow-up (post-deploy)

Purge existing `toranot_errors` rows — they predate the scrub and may hold PHI. I'll run that **after** this merges + deploys (so the app isn't still writing unscrubbed rows during the gap), confirming the project id + row count first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)