### PR TITLE
fix(rules): comfort-care suppression requires explicit flag, never inferred from sedation [P0]

### DIFF
--- a/src/__tests__/comfortCare.test.ts
+++ b/src/__tests__/comfortCare.test.ts
@@ -147,21 +147,24 @@ describe("Comfort care / palliative hints", () => {
   });
 });
 
-// ── Regression: Hebrew Dormicum (dורמיקום) ──────────────────────────────────
+// ── Regression: sedation alone must NOT infer comfort-care (P0 clinical-safety fix) ──
+// A former COMFORT_SEDATION_PATTERN flipped comfort-care from a bare fentanyl+midazolam
+// co-presence and silently suppressed the entire workup. It was removed: routine
+// ICU/procedural sedation is NOT end-of-life. These tests previously asserted
+// suppression (toBeUndefined) — they are now INVERTED to assert the corrected,
+// safe behavior: sedation regimens (any spelling) no longer suppress, so the COPD
+// workup must still generate. Explicit comfort flags are tested above.
 
-describe("COMFORT_SEDATION_PATTERN — Hebrew Dormicum regression", () => {
-  it("detects comfort from Hebrew dormicum + fentanyl (exact image text)", () => {
-    // Bug: pattern had 'dormicum' but not Hebrew spelling
-    // Image shows: "תחת דורמיקום 10 fentanyl"
+describe("sedation alone does NOT infer comfort-care (COMFORT_SEDATION_PATTERN removed)", () => {
+  it("Hebrew דורמיקום + fentanyl alone → COPD workup still generates", () => {
     const p = makePatient({
       status: ["תחת דורמיקום 10 fentanyl"],
       tasks: [{ text: "COPD exacerbation" }],
     });
-    const tasks = applyRules(p);
-    expect(tasks.find(t => t.generatedFrom === "החמרת COPD")).toBeUndefined();
+    expect(applyRules(p).find(t => t.generatedFrom === "החמרת COPD")).toBeDefined();
   });
 
-  it("does NOT trigger from fentanyl alone", () => {
+  it("fentanyl alone → COPD workup generates", () => {
     const p = makePatient({
       status: ["fentanyl patch 25mcg/h"],
       tasks: [{ text: "COPD exacerbation" }],
@@ -169,7 +172,7 @@ describe("COMFORT_SEDATION_PATTERN — Hebrew Dormicum regression", () => {
     expect(applyRules(p).find(t => t.generatedFrom === "החמרת COPD")).toBeDefined();
   });
 
-  it("does NOT trigger from dormicum alone", () => {
+  it("dormicum alone → COPD workup generates", () => {
     const p = makePatient({
       status: ["דורמיקום 2.5mg PRN"],
       tasks: [{ text: "COPD exacerbation" }],
@@ -177,20 +180,20 @@ describe("COMFORT_SEDATION_PATTERN — Hebrew Dormicum regression", () => {
     expect(applyRules(p).find(t => t.generatedFrom === "החמרת COPD")).toBeDefined();
   });
 
-  it("detects English dormicum + fentanyl", () => {
+  it("English dormicum + fentanyl alone → COPD workup generates", () => {
     const p = makePatient({
       status: ["dormicum + fentanyl drip"],
       tasks: [{ text: "COPD exacerbation" }],
     });
-    expect(applyRules(p).find(t => t.generatedFrom === "החמרת COPD")).toBeUndefined();
+    expect(applyRules(p).find(t => t.generatedFrom === "החמרת COPD")).toBeDefined();
   });
 
-  it("detects midazolam + fentanyl", () => {
+  it("midazolam + fentanyl alone → COPD workup generates", () => {
     const p = makePatient({
       status: ["midazolam 5 + fentanyl infusion"],
       tasks: [{ text: "COPD exacerbation" }],
     });
-    expect(applyRules(p).find(t => t.generatedFrom === "החמרת COPD")).toBeUndefined();
+    expect(applyRules(p).find(t => t.generatedFrom === "החמרת COPD")).toBeDefined();
   });
 });
 

--- a/src/__tests__/comfortSedationP0.test.ts
+++ b/src/__tests__/comfortSedationP0.test.ts
@@ -1,0 +1,116 @@
+/**
+ * P0 clinical-safety regression — comfort-sedation auto-suppression.
+ *
+ * Bug (pre-fix): a bare fentanyl+midazolam co-presence (COMFORT_SEDATION_PATTERN)
+ * flipped isComfortCarePatient=true and silently suppressed the ENTIRE emergency
+ * workup (sepsis/AKI/pneumonia/ACS…). Reproduced as 0 blood-culture/lactate tasks
+ * for a septic intubated patient on routine ICU sedation.
+ *
+ * Fix: comfort-care suppression now requires an EXPLICIT designation —
+ *   clinicalMeta.goalsOfCare === "comfort_only"  OR
+ *   explicit comfort/palliative/EOL text (COMFORT_CARE_PATTERN).
+ * Drug regimens never infer comfort goals. And whenever suppression IS active it
+ * is made VISIBLE via a "מצב טיפול תומך" indicator task (never silent).
+ *
+ * These assertions pin the corrected behavior. If COMFORT_SEDATION_PATTERN is
+ * ever re-introduced, the first three tests fail loudly.
+ */
+import { describe, it, expect } from "vitest";
+import { applyRules, isComfortCarePatient } from "../engine/rules";
+import type { PatientEntry } from "../types";
+
+function makePatient(overrides: Partial<PatientEntry>): PatientEntry {
+  return {
+    id: "p0-pt",
+    section: "SIDE_A",
+    date: "01/01/2025",
+    room: "101",
+    name: "Test",
+    age: 80,
+    diagnosis: null,
+    flags: [],
+    status: [],
+    tomorrowNotes: [],
+    planNotes: [],
+    tasks: [],
+    generatedTasks: [],
+    notes: [],
+    scannedAt: "2025-01-01T00:00:00.000Z",
+    confidence: 1,
+    ...overrides,
+  };
+}
+
+const task = (text: string) => ({
+  id: "t-1",
+  text,
+  urgency: "routine" as const,
+  source: "extracted" as const,
+  done: false,
+  doneTime: null,
+  time: null,
+  confidence: 1,
+});
+
+const INDICATOR = "מצב טיפול תומך";
+
+describe("P0: sedation alone NEVER infers comfort-care (the bug)", () => {
+  it("septic intubated patient on fentanyl+midazolam (NO comfort flag) → NOT comfort, full sepsis workup generates", () => {
+    const p = makePatient({
+      tasks: [task("ספסיס - חום 39.2, חשד למקור, לקטט + תרביות")],
+      status: ["מונשם", "fentanyl drip 50mcg/h + midazolam drip 5mg/h"],
+    });
+    expect(isComfortCarePatient(p)).toBe(false);
+
+    const tasks = applyRules(p);
+    // The emergency workup that was silently suppressed must now generate.
+    expect(tasks.some((t) => /תרביות דם/.test(t.text))).toBe(true); // blood cultures
+    expect(tasks.some((t) => /לקטט/.test(t.text))).toBe(true); // lactate
+    expect(tasks.some((t) => t.generatedFrom === "ספסיס")).toBe(true);
+    // And the comfort-care indicator must NOT appear for a non-comfort patient.
+    expect(tasks.some((t) => t.generatedFrom === INDICATOR)).toBe(false);
+  });
+
+  it("English dormicum+fentanyl alone → NOT comfort (COPD workup still generates)", () => {
+    const p = makePatient({
+      status: ["dormicum + fentanyl drip"],
+      tasks: [task("COPD exacerbation")],
+    });
+    expect(isComfortCarePatient(p)).toBe(false);
+    expect(applyRules(p).find((t) => t.generatedFrom === "החמרת COPD")).toBeDefined();
+  });
+
+  it("Hebrew דורמיקום+fentanyl alone → NOT comfort", () => {
+    const p = makePatient({ status: ["תחת דורמיקום 10 fentanyl"] });
+    expect(isComfortCarePatient(p)).toBe(false);
+  });
+});
+
+describe("P0: explicit comfort-care still suppresses AND is now visible (never silent)", () => {
+  it("structured goalsOfCare=comfort_only → sepsis suppressed + visible indicator present", () => {
+    const p = makePatient({
+      tasks: [task("ספסיס - חום 39, לקטט + תרביות")],
+      clinicalMeta: { goalsOfCare: "comfort_only" },
+    });
+    expect(isComfortCarePatient(p)).toBe(true);
+
+    const tasks = applyRules(p);
+    expect(tasks.some((t) => t.generatedFrom === "ספסיס")).toBe(false); // suppressed
+    expect(tasks.some((t) => t.generatedFrom === INDICATOR)).toBe(true); // visible
+  });
+
+  it("explicit comfort TEXT (טיפול מנחם) → suppressed + visible indicator present", () => {
+    const p = makePatient({
+      flags: ["טיפול מנחם"],
+      tasks: [task("ספסיס - חום 39, תרביות")],
+    });
+    const tasks = applyRules(p);
+    expect(tasks.some((t) => t.generatedFrom === "ספסיס")).toBe(false);
+    expect(tasks.some((t) => t.generatedFrom === INDICATOR)).toBe(true);
+  });
+
+  it("regular (non-comfort) patient → NO indicator task", () => {
+    const p = makePatient({ tasks: [task("חום 39.2")] });
+    expect(applyRules(p).some((t) => t.generatedFrom === INDICATOR)).toBe(false);
+  });
+});

--- a/src/__tests__/rules.comfort.test.ts
+++ b/src/__tests__/rules.comfort.test.ts
@@ -69,8 +69,11 @@ describe("isComfortCarePatient", () => {
     expect(isComfortCarePatient(makePatient({ flags: ["טיפול מנחם"] }))).toBe(true);
   });
 
-  it("detects comfort sedation (fentanyl + dormicum)", () => {
-    expect(isComfortCarePatient(makePatient({ status: ["fentanyl drip + dormicum IV"] }))).toBe(true);
+  it("does NOT infer comfort from sedation alone (fentanyl + dormicum) — P0 fix", () => {
+    // INVERTED (was .toBe(true)): COMFORT_SEDATION_PATTERN removed. Routine
+    // ICU/procedural sedation is not EOL — comfort-care now requires an explicit
+    // flag (goalsOfCare === "comfort_only" or comfort/palliative/EOL text).
+    expect(isComfortCarePatient(makePatient({ status: ["fentanyl drip + dormicum IV"] }))).toBe(false);
   });
 
   it("detects clinicalMeta.goalsOfCare = comfort_only", () => {

--- a/src/engine/rules.ts
+++ b/src/engine/rules.ts
@@ -42,9 +42,16 @@ interface Rule {
 // Only explicit comfort/palliative flags trigger suppression.
 const COMFORT_CARE_PATTERN =
   /comfort\s*care|palliative|פליאטיב|טיפול תומך בלבד|טיפול מנחם|EOL|end.of.life|הנוחות בלבד|טיפולי נוחות/i;
-// High-dose combined sedation (fentanyl + dormicum/midazolam) strongly implies end-of-life comfort sedation
-const COMFORT_SEDATION_PATTERN =
-  /(?=.*(?:fentanyl|פנטניל))(?=.*(?:dormicum|דורמיקום|midazolam|מידזולם|מידאזולם))/i;
+// ⚠️ DO NOT re-add a drug-co-presence comfort trigger. A former
+// COMFORT_SEDATION_PATTERN inferred comfort-care from bare fentanyl+midazolam
+// co-presence. It was removed in the P0 clinical-safety fix: that combination is
+// routine ICU / step-down / procedural sedation and does NOT imply end-of-life.
+// It silently flipped isComfortCarePatient=true and suppressed the ENTIRE
+// emergency workup (sepsis/AKI/pneumonia/ACS…) for non-EOL patients — verified
+// as 0 sepsis tasks for a septic intubated patient. Comfort-care suppression now
+// REQUIRES an explicit designation: clinicalMeta.goalsOfCare === "comfort_only"
+// OR explicit comfort/palliative/EOL text (COMFORT_CARE_PATTERN). Never infer
+// comfort goals from sedation drugs.
 
 // Rule groups that are suppressed for comfort-care-only patients.
 // These represent aggressive workup/intervention that conflicts with comfort goals.
@@ -1648,8 +1655,7 @@ export function isComfortCarePatient(patient: PatientEntry): boolean {
   ].join(" ");
   return (
     patient.clinicalMeta?.goalsOfCare === "comfort_only" ||
-    COMFORT_CARE_PATTERN.test(signal) ||
-    COMFORT_SEDATION_PATTERN.test(signal)
+    COMFORT_CARE_PATTERN.test(signal)
   );
 }
 
@@ -1680,8 +1686,7 @@ export function applyRules(patient: PatientEntry): Task[] {
   ].join(" ");
   const isComfortCareOnly =
     patient.clinicalMeta?.goalsOfCare === "comfort_only" ||
-    COMFORT_CARE_PATTERN.test(comfortSignalText) ||
-    COMFORT_SEDATION_PATTERN.test(comfortSignalText);
+    COMFORT_CARE_PATTERN.test(comfortSignalText);
   const allFlags = comfortSignalText; // keep allFlags for backward compat with any callers
 
   // Pre-build text blobs for each trigger scope
@@ -1763,6 +1768,29 @@ export function applyRules(patient: PatientEntry): Task[] {
         });
       }
     }
+  }
+
+  // ── Visible comfort-care suppression indicator (P0 clinical-safety) ──
+  // Comfort-care suppression must NEVER be silent. When comfort-care mode is
+  // active, aggressive workup (sepsis/AKI/pneumonia/ACS…) is auto-suppressed —
+  // so the on-call doctor must not misread a short/empty task list as
+  // "nothing to do". Gated on isComfortCareOnly so it fires for EXACTLY the
+  // suppressed patient set (same condition that drives suppression above).
+  // Appears as one routine generated task (intentionally counted in task
+  // lists / handoff totals — that visibility is the point).
+  if (isComfortCareOnly) {
+    generated.push({
+      id: generateId("gen-"),
+      text: "טיפול תומך (comfort care) פעיל — בירור/טיפול אגרסיבי אינו נוצר אוטומטית. ודא שיעדי הטיפול מעודכנים.",
+      urgency: "routine",
+      category: "other",
+      source: "generated",
+      done: false,
+      doneTime: null,
+      time: null,
+      confidence: 1,
+      generatedFrom: "מצב טיפול תומך",
+    });
   }
 
   // Deduplicate: if two rules independently generated an identical task text,


### PR DESCRIPTION
## 🔴 P0 clinical-safety — silent suppression of the entire emergency workup

**Bug:** a bare **fentanyl + midazolam** drug co-presence (`COMFORT_SEDATION_PATTERN`, `rules.ts:46`) flipped `isComfortCarePatient = true` (`:1652`, `:1684`) and silently suppressed **every** aggressive-workup group (`COMFORT_SUPPRESSED_GROUPS`: sepsis, AKI, pneumonia, ACS, CHF, UTI, hyperK, hypoNa…). Fentanyl + midazolam is **routine ICU / step-down / procedural sedation** — it does **not** imply end-of-life.

**Reproduced empirically** (septic, intubated, fentanyl drip + midazolam drip, **no** comfort/EOL text):

| | `isComfortCarePatient` | total tasks | blood cultures | lactate | indicator |
|---|---|---|---|---|---|
| **BEFORE** (buggy) | `true` ❌ | **2** | ❌ none | ❌ none | — (silent) |
| **AFTER** (fixed) | `false` ✅ | **18** | ✅ generated | ✅ generated | absent (correct — not comfort) |

BEFORE, the engine emitted 2 *comfort-symptom-check* tasks for a septic patient. AFTER: sepsis ×7 (cultures, lactate, broad-spectrum abx…), fever ×5, opioid/midazolam monitoring ×6.

## The fix (`src/engine/rules.ts`, surgical — P0 only)

1. **Removed `COMFORT_SEDATION_PATTERN`** (definition + both detection sites). Comfort-care suppression now **requires an explicit designation**:
   - structured `clinicalMeta.goalsOfCare === "comfort_only"`, **or**
   - explicit comfort/palliative/EOL **text** (`COMFORT_CARE_PATTERN` — unchanged).
   - A **regression-guard comment** at the former site forbids re-adding any drug-co-presence trigger.
2. **Visible indicator (never silent)** — when `isComfortCareOnly` is active, `applyRules` emits one `routine` **"מצב טיפול תומך"** task stating aggressive workup is auto-suppressed. Gated on the **same** `isComfortCareOnly` condition that drives suppression → fires for *exactly* the suppressed set.

## Decisions surfaced (per CLAUDE.md Working Rule #1)

- **Kept `COMFORT_CARE_PATTERN` (explicit text).** It is explicit comfort-care *documentation*, not a drug inference; removing it would be scope creep past the P0 and break the tested free-text workflow. If you'd rather gate suppression on the **structured field only** (`goalsOfCare`), that's a one-line follow-up (it would stop suppressing for text-only-documented comfort patients — strictly fail-open). **Your call.**
- **Indicator counts as one task** in handoff/badge totals (`HandoffSheet` pendingCount, `ParsePreview` totals). That visibility is intentional; I did **not** add exclusion code across the ~10 count sites (would be the real "change everything" scope creep). If you'd prefer a non-counted UI banner, that's a follow-up.

## Tests
- **`comfortSedationP0.test.ts`** (new, 6): sedation alone never infers comfort; explicit comfort (structured + text) still suppresses **and** shows the indicator; non-comfort → no indicator.
- **`comfortCare.test.ts` / `rules.comfort.test.ts`**: assertions that encoded the bug (sedation co-presence → suppression) **inverted** to the corrected behavior, kept as regression guards.
- Full suite **2321 pass**, typecheck + build clean. No version bump (SW auto-stamps at build).

## ⚠️ Do NOT self-merge
Clinical-safety + patient-logic path. Per CLAUDE.md sign-off rule and Eias's explicit instruction: **Codex review + CI green, then STOP for Eias to review + merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)