### PR TITLE
fix(auth): cloud-sync labels rendered raw \uXXXX escapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 ## Recent Changes
 
+### Cloud-sync labels rendered raw \uXXXX escapes — fixed (2026-06-04)
+
+- **Bug:** the overflow-menu cloud-sync status (`☁️ מסונכרן`), the disconnect button (`התנתק מהענן`), and the logged-out auth labels in `CloudAuthPanel.tsx` displayed literal backslash-u text instead of Hebrew/emoji.
+- **Root cause:** JSX does not decode `\uXXXX` escapes in **text children** — only inside string literals (`{"..."}`) or attribute values. The file uses ASCII escapes for Hebrew (to avoid the U+200F LRM `str_replace` trap), and 7 labels sat in JSX text position.
+- **Fix:** wrapped the 7 text-node escapes in `{"..."}` (keeps the ASCII-escape convention, decodes correctly).
+- **Guard:** `src/__tests__/jsxTextEscapeGuard.test.ts` statically scans all `.tsx` and fails the build on any unicode escape in JSX text position (verified it pinpoints the offending line when re-broken).
+
 ### Admission workflow upgrade + room format fix (2026-04-10)
 
 **Geriatric baseline on admission:**

--- a/src/__tests__/jsxTextEscapeGuard.test.ts
+++ b/src/__tests__/jsxTextEscapeGuard.test.ts
@@ -1,0 +1,57 @@
+/**
+ * JSX-text unicode-escape guard.
+ *
+ * Root cause (CloudAuthPanel mojibake, 2026-06-04): a `\uXXXX` escape written as
+ * JSX *text children* (e.g. `<div>\u05de\u05e1...</div>`) is NOT decoded by JSX —
+ * it renders the literal backslash-u text. Escapes only decode inside a string
+ * literal (`{"\u05de..."}`) or an attribute value (`aria-label="\u05de..."`).
+ *
+ * The repo intentionally uses ASCII `\uXXXX` escapes for Hebrew (to dodge the
+ * U+200F LRM str_replace trap), so this trap is easy to reintroduce and ships
+ * silently green. This static scan fails the build if any component puts a
+ * unicode escape in JSX text position.
+ *
+ * Fix when this fails: wrap the text in `{"..."}` or use the real glyph.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+function walkTsx(dir: string, acc: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      if (name === "__tests__" || name === "node_modules") continue;
+      walkTsx(full, acc);
+    } else if (name.endsWith(".tsx")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// Shape 1: escape immediately after a tag close `>` (same line), e.g. `>\u05de...`
+const AFTER_TAG = />\s*\\u[0-9a-fA-F]{4}/;
+// Shape 2: a standalone JSX-text line that is only escapes (no quote = not a string literal)
+const STANDALONE_LINE = /^\s*\\u[0-9a-fA-F]{4}[^"']*$/;
+
+describe("JSX-text unicode-escape guard", () => {
+  const files = walkTsx(join(process.cwd(), "src"));
+
+  it("finds .tsx files to scan", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("has no unicode escapes in JSX text position (they render literally)", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, i) => {
+        if (AFTER_TAG.test(line) || STANDALONE_LINE.test(line)) {
+          offenders.push(`${file.replace(process.cwd() + "/", "")}:${i + 1}  ${line.trim()}`);
+        }
+      });
+    }
+    expect(offenders, `JSX-text escapes render literally — wrap in {"..."}:\n${offenders.join("\n")}`).toEqual([]);
+  });
+});

--- a/src/components/CloudAuthPanel.tsx
+++ b/src/components/CloudAuthPanel.tsx
@@ -63,10 +63,10 @@ export function CloudAuthPanel() {
   if (user) {
     return (
       <div className="px-4 py-3 border-t border-slate-700 text-right">
-        <div className="text-xs text-green-400 mb-1.5">\u2601\ufe0f \u05de\u05e1\u05d5\u05e0\u05db\u05e8\u05df</div>
+        <div className="text-xs text-green-400 mb-1.5">{"\u2601\ufe0f \u05de\u05e1\u05d5\u05e0\u05db\u05e8\u05df"}</div>
         <div className="text-[11px] text-slate-400 mb-2 truncate" dir="ltr">{user.email}</div>
         <button onClick={() => signOut()} className="text-[11px] text-red-400 active:text-red-300">
-          \u05d4\u05ea\u05e0\u05ea\u05e7 \u05de\u05d4\u05e2\u05e0\u05df
+          {"\u05d4\u05ea\u05e0\u05ea\u05e7 \u05de\u05d4\u05e2\u05e0\u05df"}
         </button>
       </div>
     );
@@ -119,23 +119,23 @@ export function CloudAuthPanel() {
         <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         {loading ? "..." : "\u05db\u05e0\u05d9\u05e1\u05d4 \u05e2\u05dd GitHub"}
       </button>
-      <div className="text-center text-[10px] text-slate-400">\u2014 \u05d0\u05d5 \u2014</div>
+      <div className="text-center text-[10px] text-slate-400">{"\u2014 \u05d0\u05d5 \u2014"}</div>
       {/* Login / Signup toggle */}
       <div className="flex rounded-lg overflow-hidden border border-slate-600 text-xs">
         <button
           onClick={(e) => { e.stopPropagation(); setMode("login"); setError(null); }}
           className={"flex-1 py-1.5 transition-colors " + (mode === "login" ? "bg-blue-600 text-white" : "bg-slate-800 text-slate-400")}
         >
-          \u05db\u05e0\u05d9\u05e1\u05d4
+          {"\u05db\u05e0\u05d9\u05e1\u05d4"}
         </button>
         <button
           onClick={(e) => { e.stopPropagation(); setMode("signup"); setError(null); }}
           className={"flex-1 py-1.5 transition-colors " + (mode === "signup" ? "bg-blue-600 text-white" : "bg-slate-800 text-slate-400")}
         >
-          \u05d4\u05e8\u05e9\u05de\u05d4
+          {"\u05d4\u05e8\u05e9\u05de\u05d4"}
         </button>
       </div>
-      <label htmlFor="cloud-auth-email" className="sr-only">\u05db\u05ea\u05d5\u05d1\u05ea \u05de\u05d9\u05d9\u05dc</label>
+      <label htmlFor="cloud-auth-email" className="sr-only">{"\u05db\u05ea\u05d5\u05d1\u05ea \u05de\u05d9\u05d9\u05dc"}</label>
       <input
         id="cloud-auth-email"
         type="email"
@@ -148,7 +148,7 @@ export function CloudAuthPanel() {
         aria-label="\u05db\u05ea\u05d5\u05d1\u05ea \u05de\u05d9\u05d9\u05dc"
         className="w-full bg-slate-900 border border-slate-600 text-slate-200 text-xs px-2.5 py-2 rounded-lg placeholder:text-slate-500 focus:outline-none focus:border-blue-500"
       />
-      <label htmlFor="cloud-auth-password" className="sr-only">\u05e1\u05d9\u05e1\u05de\u05d4</label>
+      <label htmlFor="cloud-auth-password" className="sr-only">{"\u05e1\u05d9\u05e1\u05de\u05d4"}</label>
       <input
         id="cloud-auth-password"
         type="password"


### PR DESCRIPTION
**Bug** (visible in overflow menu): `☁️ מסונכרן`, `התנתק מהענן`, and logged-out auth labels rendered literal backslash-u text.

**Root cause** (`src/components/CloudAuthPanel.tsx`): JSX does not decode `\uXXXX` in text children — only in string literals `{"..."}` / attributes. 7 labels sat in JSX text position. file:line — CloudAuthPanel.tsx:66,69,122,129,135,138,151.

**Fix:** wrapped the 7 text-node escapes in `{"..."}` (keeps ASCII-escape convention).

**Guard:** `src/__tests__/jsxTextEscapeGuard.test.ts` scans all .tsx, fails on any unicode escape in JSX text position. Verified it pinpoints CloudAuthPanel.tsx:66 when re-broken.

Local: tsc 0 errors · vitest 2323 passed (+2) · build OK (146.5KB).