### PR TITLE
fix(scanner): broaden image decode (createImageBitmap) + legible HEIC failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## Recent Changes
 
+### Scanner: broaden image decode (HEIC) + legible decode failure (2026-06-04)
+
+- **Symptom:** a clean printed ward sheet "couldn't scan" with no useful error.
+- **Diagnosis:** OCR backend proven working (extracted all 11 rows + section header against the real sheet via the proxy). Failure was the **client-side decode**: `fileToBase64` used `new Image()` + `<canvas>`, which on Android cannot decode HEIC, and `img.onerror` rejected with a raw event so the user saw `[object Event]`.
+- **Fix:** decode via `createImageBitmap()` first (native codecs — decodes HEIF/HEIC on capable devices, respects EXIF), fall back to `<img>`; on total decode failure throw a clear Hebrew error ("פורמט התמונה לא נתמך (ייתכן HEIC) — צלם מחדש או שמור כ-JPG"). All resize/contrast/quality logic unchanged; no bundle bloat.
+
 ### Cloud-sync labels rendered raw \uXXXX escapes — fixed (2026-06-04)
 
 - **Bug:** the overflow-menu cloud-sync status (`☁️ מסונכרן`), the disconnect button (`התנתק מהענן`), and the logged-out auth labels in `CloudAuthPanel.tsx` displayed literal backslash-u text instead of Hebrew/emoji.

--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -231,40 +231,63 @@ async function runClaudeOCR(file: File, apiKey: string, sectionHint?: string): P
     .join("\n");
 }
 
-// Resize + compress + sharpen image for optimal OCR accuracy
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
+// Decode a File into a canvas-drawable source. Tries createImageBitmap first
+// (uses native platform codecs — decodes HEIF/HEIC on capable devices and
+// respects EXIF orientation), and falls back to <img> decode for older
+// browsers. Throws a clear, actionable error when the format can't be decoded
+// at all — the common silent failure when a phone hands the picker a HEIC file
+// that the browser's <img> canvas can't read.
+async function decodeImage(file: File): Promise<ImageBitmap | HTMLImageElement> {
+  if (typeof createImageBitmap === "function") {
+    try {
+      return await createImageBitmap(file, { imageOrientation: "from-image" });
+    } catch {
+      // fall through to the <img> path
+    }
+  }
+  return await new Promise<HTMLImageElement>((resolve, reject) => {
     const img = new Image();
     const url = URL.createObjectURL(file);
-    img.onload = () => {
-      let { width, height } = img;
-      if (width > IMAGE_MAX_EDGE || height > IMAGE_MAX_EDGE) {
-        if (width > height) { height = Math.round(height * IMAGE_MAX_EDGE / width); width = IMAGE_MAX_EDGE; }
-        else { width = Math.round(width * IMAGE_MAX_EDGE / height); height = IMAGE_MAX_EDGE; }
-      }
-      const canvas = document.createElement("canvas");
-      canvas.width = width;
-      canvas.height = height;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) { reject(new Error("Failed to get canvas 2D context")); return; }
-
-      // Draw base image
-      ctx.drawImage(img, 0, 0, width, height);
-
-      // Apply light sharpening via unsharp mask for OCR clarity
-      // Boost contrast slightly — helps with faded printouts and phone photos
-      ctx.filter = "contrast(1.15) brightness(1.02)";
-      ctx.globalCompositeOperation = "source-over";
-      ctx.drawImage(canvas, 0, 0);
-      ctx.filter = "none";
-
+    img.onload = () => { URL.revokeObjectURL(url); resolve(img); };
+    img.onerror = () => {
       URL.revokeObjectURL(url);
-      const dataUrl = canvas.toDataURL("image/jpeg", IMAGE_JPEG_QUALITY);
-      resolve(dataUrl.split(",")[1]);
+      reject(new Error("פורמט התמונה לא נתמך (ייתכן HEIC) — צלם מחדש או שמור כ-JPG"));
     };
-    img.onerror = reject;
     img.src = url;
   });
+}
+
+// Resize + compress + sharpen image for optimal OCR accuracy
+async function fileToBase64(file: File): Promise<string> {
+  const source = await decodeImage(file);
+  let width = source.width;
+  let height = source.height;
+  if (width > IMAGE_MAX_EDGE || height > IMAGE_MAX_EDGE) {
+    if (width > height) { height = Math.round(height * IMAGE_MAX_EDGE / width); width = IMAGE_MAX_EDGE; }
+    else { width = Math.round(width * IMAGE_MAX_EDGE / height); height = IMAGE_MAX_EDGE; }
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    if ("close" in source) source.close();
+    throw new Error("Failed to get canvas 2D context");
+  }
+
+  // Draw base image
+  ctx.drawImage(source, 0, 0, width, height);
+
+  // Apply light sharpening via unsharp mask for OCR clarity
+  // Boost contrast slightly — helps with faded printouts and phone photos
+  ctx.filter = "contrast(1.15) brightness(1.02)";
+  ctx.globalCompositeOperation = "source-over";
+  ctx.drawImage(canvas, 0, 0);
+  ctx.filter = "none";
+
+  if ("close" in source) source.close();
+  const dataUrl = canvas.toDataURL("image/jpeg", IMAGE_JPEG_QUALITY);
+  return dataUrl.split(",")[1];
 }
 
 function getStoredKey(): string {


### PR DESCRIPTION
**Symptom:** a clean printed ward sheet couldn't scan, no useful error.

**Diagnosis (cited):** ran the app's exact OCR call (sonnet-4-6, same prompt, 4096 tok, faithful resize) against the real sheet via `/api/claude` — extracted **11/11 patient rows + the צד א header**, rooms exact (49-1…71-1), `end_turn`, 919 tok. OCR/prompt/proxy are fine. Failure is client-side decode: `fileToBase64` used `new Image()`+`<canvas>` (cannot decode HEIC on Android) and `img.onerror` rejected with a raw event → user saw `[object Event]`.

**Fix:** `createImageBitmap()` first (native codecs, HEIF/HEIC on capable devices, EXIF-correct) → `<img>` fallback → clear Hebrew error on total decode failure. Resize/contrast/quality unchanged. file:line — Scanner.tsx decodeImage()+fileToBase64.

Local: tsc 0 · vitest 2323 passed · build OK (Scanner 18.84KB).