### PR TITLE
fix(scanner): decode HEIC via lazy-loaded WASM (heic2any)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ## Recent Changes
 
+### Scanner: decode HEIC via lazy WASM (2026-06-04)
+
+- Confirmed on-device: the Oppo's `createImageBitmap` also can't decode HEIC (no OS HEIF codec exposed), so the prior native-decode path still couldn't scan HEIC — only showed the clear error.
+- Fix: detect HEIC/HEIF (MIME or extension; Android often reports empty MIME) and convert to JPEG via `heic2any` (libheif WASM), dynamically imported only on the HEIC path. Separate ~1.35MB chunk (gzip 341KB), SW-cached after first use; main bundle stays 146.5KB, JPEG/PNG flow unchanged.
+
 ### Dependency refresh (within-range) + declare @types/node (2026-06-04)
 
 - `npm update` bumped all deps to the latest within their caret ranges (react 19.2.7, @supabase/supabase-js 2.107.0, vite 7.3.5, @vitejs/plugin-react 5.2.0, dompurify 3.4.8, zustand 5.0.14, vitest/coverage 4.1.8, etc.). Majors held back deliberately: vite 8, typescript 6, @vitejs/plugin-react 6.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.49.0",
         "dexie": "^4.3.0",
         "dompurify": "^3.1.6",
+        "heic2any": "^0.0.4",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -2425,6 +2426,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@supabase/supabase-js": "^2.49.0",
     "dexie": "^4.3.0",
     "dompurify": "^3.1.6",
+    "heic2any": "^0.0.4",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -231,27 +231,47 @@ async function runClaudeOCR(file: File, apiKey: string, sectionHint?: string): P
     .join("\n");
 }
 
-// Decode a File into a canvas-drawable source. Tries createImageBitmap first
-// (uses native platform codecs — decodes HEIF/HEIC on capable devices and
-// respects EXIF orientation), and falls back to <img> decode for older
-// browsers. Throws a clear, actionable error when the format can't be decoded
-// at all — the common silent failure when a phone hands the picker a HEIC file
-// that the browser's <img> canvas can't read.
+// True if the file is HEIC/HEIF. Android often reports an empty MIME type for
+// these, so fall back to the filename extension.
+function isHeic(file: File): boolean {
+  const t = (file.type || "").toLowerCase();
+  if (t === "image/heic" || t === "image/heif") return true;
+  if (t === "") return /\.(heic|heif)$/i.test(file.name);
+  return false;
+}
+
+// Decode a File into a canvas-drawable source. HEIC/HEIF can't be decoded by
+// <img> or createImageBitmap on most Android devices (the OS codec isn't
+// exposed to the browser), so those are converted to JPEG via a WASM decoder
+// that is lazy-loaded ONLY on the HEIC path — the normal JPEG/PNG flow and the
+// main bundle are untouched. Then createImageBitmap is tried first (native
+// codecs, EXIF-correct) with an <img> fallback, and a clear, actionable error
+// is thrown when nothing can decode the image.
 async function decodeImage(file: File): Promise<ImageBitmap | HTMLImageElement> {
+  let decodable: Blob = file;
+  if (isHeic(file)) {
+    try {
+      const heic2any = (await import("heic2any")).default;
+      const out = await heic2any({ blob: file, toType: "image/jpeg", quality: 0.9 });
+      decodable = Array.isArray(out) ? out[0] : out;
+    } catch {
+      throw new Error("המרת HEIC נכשלה — צלם מחדש או שמור כ-JPG");
+    }
+  }
   if (typeof createImageBitmap === "function") {
     try {
-      return await createImageBitmap(file, { imageOrientation: "from-image" });
+      return await createImageBitmap(decodable, { imageOrientation: "from-image" });
     } catch {
       // fall through to the <img> path
     }
   }
   return await new Promise<HTMLImageElement>((resolve, reject) => {
     const img = new Image();
-    const url = URL.createObjectURL(file);
+    const url = URL.createObjectURL(decodable);
     img.onload = () => { URL.revokeObjectURL(url); resolve(img); };
     img.onerror = () => {
       URL.revokeObjectURL(url);
-      reject(new Error("פורמט התמונה לא נתמך (ייתכן HEIC) — צלם מחדש או שמור כ-JPG"));
+      reject(new Error("פורמט התמונה לא נתמך — צלם מחדש או שמור כ-JPG"));
     };
     img.src = url;
   });

--- a/src/heic2any.d.ts
+++ b/src/heic2any.d.ts
@@ -1,0 +1,11 @@
+declare module "heic2any" {
+  interface Heic2AnyOptions {
+    blob: Blob;
+    toType?: string;
+    quality?: number;
+    multiple?: boolean;
+    gifInterval?: number;
+  }
+  function heic2any(options: Heic2AnyOptions): Promise<Blob | Blob[]>;
+  export default heic2any;
+}


### PR DESCRIPTION
Confirmed on-device (screenshot 21:18): the Oppo's `createImageBitmap` also can't decode HEIC — the native-decode path only surfaced the clear error. No client API decodes HEIC natively on this device.

**Fix:** detect HEIC/HEIF (MIME or `.heic/.heif` extension — Android reports empty MIME for these) and convert to JPEG via `heic2any` (libheif WASM), **dynamically imported ONLY on the HEIC path**. Build confirms a separate **1.35MB chunk** (gzip 341KB); **main index bundle unchanged at 146.5KB**; JPEG/PNG flow untouched. SW caches the chunk after first use. Clear Hebrew error retained on conversion/decode failure.

tsc 0 · vitest 2323 passed · build OK.