### PR TITLE
chore(repo): commit Codex/agent scaffolding (AGENTS.md + .agents + .codex)

### DIFF
--- a/.agents/skills/add-clinical-rule/SKILL.md
+++ b/.agents/skills/add-clinical-rule/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: add-clinical-rule
+description: Add a clinical rule to Toranot's src/engine/rules.ts with the Golden Rule invariant, unique group check, comfort-care suppression audit, and automatic test scaffolding. Use when user says "add a rule", "new rule", "add clinical rule", "new trigger in rules.ts", or when proposing a new auto-generated task pattern for the rules engine. DO NOT use for drug interactions (those live in drugSafety.ts).
+---
+
+# Add Clinical Rule — Toranot Rules Engine
+
+Guards `src/engine/rules.ts` against the most common screw-ups:
+1. Auto-generating tasks a nurse/morning team should handle (violates Golden Rule).
+2. Duplicate `group` keys (breaks dedup).
+3. Missing test + `RULES.length` assertion update.
+4. Not checking comfort-care suppression where clinically appropriate.
+5. Trigger field too broad (scanning planNotes/tomorrowNotes — forbidden).
+
+## Workflow (strict order)
+
+### 1 — Validate against the Golden Rule
+Before writing any code, state the proposed rule in plain English and answer:
+
+> "Is this something the on-call doctor MUST act on during this shift?"
+
+If the answer is "nice to have", "for morning team", "standing order", "nursing task",
+"textbook ladder", or "social work referral" → **STOP**. This does not belong in rules.ts.
+Consider `QuickReference.tsx` or `OnCallProtocols.tsx` instead.
+
+### 2 — Check for group collision
+```
+grep -n "group:" src/engine/rules.ts | awk -F'"' '{print $2}' | sort | uniq -d
+```
+Then verify the proposed new `group` is not in the existing list:
+```
+grep -c "group: \"<proposed_group>\"" src/engine/rules.ts
+# Expect 0
+```
+
+### 3 — Choose the narrowest trigger field
+- `"diagnosis"` — only when the rule truly depends on admission Dx.
+- `"tasks"` — when the trigger is a status/flag/existing task.
+- `"all"` — last resort. Justify in the rule comment.
+
+**Never** expect planNotes or tomorrowNotes to match — they are excluded by the engine.
+
+### 4 — Scaffold the rule
+
+```typescript
+// Rationale: <one-line clinical justification with reference>
+{
+  trigger: /regex/i,
+  source: "Hebrew label shown to user",
+  group: "unique_snake_case",
+  triggerField: "diagnosis", // narrowest viable
+  tasks: [
+    { text: "...", urgency: "stat"|"urgent"|"routine"|"morning"|"extra",
+      category: "labs"|"meds"|"procedure"|"consult"|"other" },
+  ],
+},
+```
+
+### 5 — Confirm comfort-care suppression decision
+If the rule fires aggressive workup (labs, imaging, consults), verify:
+- `COMFORT_CARE_PATTERN` suppression already applies at the engine level, OR
+- The rule explicitly opts in/out with justification in a comment above the rule.
+
+DNR/DNI alone is NOT comfort care — do not treat it as suppression.
+
+### 6 — Write the regression test
+
+Add to `src/__tests__/rules.test.ts`:
+
+```typescript
+it("fires <rule name> on matching <trigger>", () => {
+  const patient = makePatient({ /* minimal fixture that hits the trigger */ });
+  const tasks = generateTasks(patient);
+  expect(tasks.some(t => t.generatedFrom === "<source>")).toBe(true);
+});
+
+it("does NOT fire <rule name> on comfort-care patient", () => {
+  const patient = makePatient({ diagnosis: "<trigger>", flags: ["comfort"] });
+  const tasks = generateTasks(patient);
+  expect(tasks.some(t => t.generatedFrom === "<source>")).toBe(false);
+});
+```
+
+### 7 — Bump the RULES.length assertion
+In `rules.test.ts`:
+```typescript
+expect(RULES.length).toBe(<N+1>);
+```
+Also check `rules.cross.test.ts` for counts or scenarios affected.
+
+### 8 — Run the mandatory workflow
+Invoke the `toranot-ship` skill OR manually:
+```
+npx tsc --noEmit && npx vitest run && npx vite build
+```
+
+## Checklist (print this before committing)
+
+- [ ] Rule passes the Golden Rule test (doctor-actionable this shift)
+- [ ] `group` is unique across all RULES
+- [ ] `triggerField` is the narrowest viable option
+- [ ] Rationale comment cites a source (Hazzard's / Harrison's / SZMC DAG)
+- [ ] Comfort-care suppression behavior is intentional + documented
+- [ ] Regression test added (positive case)
+- [ ] Negative test added (no fire on non-matching or comfort-care)
+- [ ] `expect(RULES.length).toBe(N+1)` bumped
+- [ ] `rules.cross.test.ts` updated if relevant
+- [ ] tsc + vitest + vite build all green
+
+## Anti-examples (do NOT ship these)
+
+```typescript
+// ❌ Nursing standing order — belongs to nursing team
+{ trigger: /דלקת עור/, tasks: [{ text: "להפוך מדי שעתיים", ... }] }
+
+// ❌ Morning team discharge planning
+{ trigger: /שחרור/, tasks: [{ text: "תאם עם סוציאלית", ... }] }
+
+// ❌ Textbook ladder as separate tasks
+{ trigger: /דליריום/, tasks: [
+  { text: "בדוק קלציום" },
+  { text: "בדוק TSH" },
+  { text: "בדוק B12" },
+  { text: "בדוק פולאט" },
+  { text: "בדוק אמוניה" },
+]}
+// ✅ Consolidate:
+{ trigger: /דליריום/, tasks: [
+  { text: "workup דליריום: Ca|TSH|B12|Folate|NH3", urgency: "urgent" }
+]}
+```

--- a/.agents/skills/source-command-audit-fix-deploy/SKILL.md
+++ b/.agents/skills/source-command-audit-fix-deploy/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: "source-command-audit-fix-deploy"
+description: "Full audit → fix → test → build → deploy → verify cycle for this repo. Auto-detects repo; captain-mode with verify-first + merge carve-outs."
+---
+
+# source-command-audit-fix-deploy
+
+Use this skill when the user asks to run the migrated source command `audit-fix-deploy`.
+
+## Command Template
+
+Run the **audit-fix-deploy** skill end-to-end for the repo in the current working directory.
+Captain mode: ACT, don't ask — but obey the VERIFY-FIRST, GATES, CITATION, and MERGE rules below.
+The skill owns the per-repo pipeline (STEP 0 detect → Audit → Fix → Test+Build → Deploy → Verify → Skill-update → Self-improve). Follow it; do not reinvent it. If it isn't already in context, load `audit-fix-deploy` + its `deploy-primitives` companion by name.
+
+Start with STEP 0 immediately. Do not ask for confirmation.
+
+## Verify-first — state is a claim until checked (Rule 5)
+- Before acting: `git log -8 --all`, read the live SW/version (`curl <live-url>/sw.js | grep CACHE`), read on-main horizon/plan docs. Treat memory, compaction summaries, and any spec as claims to verify — not a task list. A task is "open" only after you confirm it isn't already shipped on main.
+- Anchor-refresh any spec authored ≥24h ago: source-file line numbers, vitest baseline count, build-size figures, live SW version + commit SHA. Stale anchors fail silent and make gates meaningless.
+- If a referenced plan artifact is missing, STOP and flag — do not reconstruct it from memory.
+
+## Gates — declare before you run (Rule 6)
+Before any commit and before any stochastic / AI-batch run, write the explicit pass/fail criterion AND the current green baseline. No proceeding on a partial win rationalized afterward. Detector-armed: prove RED on a known-bad input before trusting any test/detector to certify GREEN.
+
+## Citation gate (Rule 7)
+Every claim about what code/infra DOES ("covered", "inherits X", "verified", "handled by Y") cites a runnable/readable artifact — test path, command, or file:line. Reading the mechanism is not verifying it; run the real artifact. Once the cited artifact is green, do not re-litigate the prose around it.
+
+## Fix priority + stop conditions
+Fix in order: RLS hole > crash/silent-failure > wrong clinical/data output > leak > cosmetic. Halt at the current phase (fix before advancing) on: RLS hole, crash, red tests, failed build, failed deploy. Never force-push over a broken deploy — rollback and investigate. Run the deploy-primitives §3 RLS sanity pass on ANY schema-adjacent change (shared Postgres across five repos); record the result line in IMPROVEMENTS.md even when clean.
+
+## Merge authority
+Branch `Codex/<slug>` → PR → CI + the repo's wired reviewer → merge → `verify-deploy`. Never push direct to main.
+- Self-merge OK only on non-audit/non-PHI after CI-green + reviewer-green.
+- STOP and HAND TO EIAS (open PR, summarize, do NOT merge): (a) audit-evidence artifacts (chaos-*, analyze_*, build_stemhash*, lib/{audit8,hashStem}*, tests/{chaosBot,*audit8}*, docs/AUDIT*/RESULT/crosswalk); (b) ward-helper CODEOWNERS paths; (c) PHI cleanup.
+- Don't unpark parked work or open a kickoff doc unless its documented trigger fired / required evidence exists.
+- This repo's on-main AGENTS.md governs repo-specific carve-outs — defer to it over this file.
+
+## Output (terse)
+Per repo: findings table (severity | file:line | issue) → fixed + self-merged (PR# + root cause + verify-deploy witness) → BLOCKED ON EIAS (carve-out PRs, one line each) → RLS result (or n/a) → anything left parked + its trigger. End with a consolidated IMPROVEMENTS.md.
+
+## Never
+Reinvent the pipeline/spec; paraphrase clinical skill content into code (verbatim port only); exceed maxAttempts>3 on extract/emit; auto-flip q.c / c_accept / curator overrides / distractor empty-slots; collapse multi-accept Qs; trust a search snippet over live state.

--- a/.agents/skills/source-command-szmc-clinical-notes/SKILL.md
+++ b/.agents/skills/source-command-szmc-clinical-notes/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: "source-command-szmc-clinical-notes"
+description: "Generate professional SZMC (Shaare Zedek Medical Center) ward clinical notes in exact institutional format. PRIMARY USE: geriatric and internal medicine ward admission notes (קבלה רפואית) and ward discharge summaries (סיכום שחרור / סיכום אשפוז זמני). Also supports ED discharge (סיכום שחרור מיון) as secondary use. Trigger on: \"כתוב לי קבלה\", \"כתוב סיכום שחרור\", \"סיכום אשפוז\", \"draft a note\", \"format this admission\", or when user uploads תיק אשפוז / EMR data / patient data. For geriatric ward notes, auto-runs Beers/STOPP-START/drug interaction analysis. Always generates HTML export for RTL copy-paste into EMR. Do not attempt ad-hoc formatting — always use this skill."
+---
+
+# source-command-szmc-clinical-notes
+
+Use this skill when the user asks to run the migrated source command `szmc-clinical-notes`.
+
+## Command Template
+
+# SZMC Clinical Notes Skill
+
+## NOTE TYPE PRIORITY
+
+**Primary (ward):** קבלה רפואית גריאטריה / רפואה פנימית — full problem-based admission note with # headers, תפקוד checklist, geriatric analysis, Padua score, functional assessment.
+
+**Primary (ward):** סיכום שחרור / סיכום אשפוז זמני — ward discharge with hospital course per # problem, discharge Rx, recommendations.
+
+**Secondary (ED):** סיכום שחרור מיון — supported but not the focus. See discharge template for ED-specific rules if needed.
+
+
+## OUTPUT FORMAT — CRITICAL
+
+**Plain text only. No HTML, no tables, no markdown formatting in the note itself.**
+
+User copies each section into SZMC EMR fields. The hospital system generates the printout.
+- No bold, no markdown headers in output
+- Labs always inline prose: `נתרן 136, אשלגן 4.8, CRP 18.4.`
+- Medications: one per line in SZMC format (see `references/medication-formats.md`)
+- Problem headers use `#` as plain text (ward notes only — not ED discharge)
+- תוכנית is a bare verb list, no bullet symbols
+
+## WORKFLOW
+
+1. Collect patient data (see Input Requirements)
+2. Determine note type — ward admission / ward discharge / ED discharge
+3. Read `references/admission-template.md` (ward admissions) or `references/discharge-template.md` (discharge/ED)
+4. Read `references/medication-formats.md` for drug formatting
+5. Generate note as plain text in chat, labeled by section
+6. Generate HTML export file (see HTML Export section)
+7. For geriatric ward notes: read `references/geriatric-analysis.md`, run analysis, show flags in chat
+
+## INPUT REQUIREMENTS
+
+**Mandatory for ward admission:** Patient demographics, HMO, department, admission date, chief complaint, active/background diagnoses (English), רקע רפואי per system, current illness narrative, home medications, physical exam, labs (inline prose), auxiliary tests (ECG, CXR, CT, US, echo), discussion and plan per # problem.
+
+**Additional for ward discharge:** Discharge date, hospital course per problem, trends in key labs, discharge medications, discharge recommendations.
+
+**ED discharge:** Shorter — vitals, exam, מהלך ודיון (no # headers), תרופות באשפוז with timestamps, המלצות, המשך טיפול תרופתי.
+
+If data is incomplete, ask targeted questions — don't invent clinical facts.
+
+## NOTE TYPES
+
+| Type | Hebrew | Format | Template |
+|------|--------|--------|----------|
+| Ward admission | קבלה רפואית | # problem headers, תפקוד MCQ, full geriatric analysis | `references/admission-template.md` |
+| Ward discharge | סיכום שחרור | # problem-based hospital course, discharge Rx | `references/discharge-template.md` |
+| Temporary ward discharge | סיכום אשפוז זמני | Same as ward discharge | `references/discharge-template.md` |
+
+
+## KEY STRUCTURAL RULES
+
+Full templates with examples are in the reference files. Summary of critical conventions:
+
+**Sections order (admission):** כותרת → הצגת החולה → אבחנות פעילות → אבחנות ברקע → ניתוחים בעבר → תלונה עיקרית → **רקע רפואי** → מחלה נוכחית → רגישויות → תרופות בבית → הרגלים → תפקוד → בדיקה גופנית → בדיקות עזר → בדיקות מעבדה → דיון ותוכנית → חתימה
+
+**Sections order (discharge/ED):** כותרת → תנועות → אבחנות פעילות → אבחנות ברקע → הצגת החולה → תלונה עיקרית → **רקע רפואי** → רגישויות → הרגלים → בדיקה גופנית → מהלך ודיון → תרופות באשפוז → תרופות בבית → פרוט ניתוחים → המלצות בשחרור → **המשך טיפול תרופתי** → תוצאות מעבדה → תרביות → חתימה
+
+**Discussion structure:**
+- Opening paragraph (patient, baseline, reason)
+- `-בקבלתו/ה למיון:` (with leading dash) — vitals, exam, workup, treatment started
+- `בקבלתו/ה למחלקתנו:` (no dash) — vitals, exam, key labs inline
+- `המטופל/ת מציג/ה את הבעיות הבאות להתייחס:`
+- `# PROBLEM` headers (3-6 sentences each) — **ward admission and ward discharge summaries only. NOT used in ED discharge notes.** Headers always in **Hebrew**. Preferred clinical category headers:
+  `# זיהומית` / `# נשימתית` / `# המודינמית` / `# המטולוגית` / `# כלייתית` / `# נוירולוגית` / `# מטבולית` / `# תפקודית` / `# לבבית` / `# עורית` / `# סוציאלית` — or specific Hebrew diagnosis name as header
+- `תוכנית:` bare verb list
+
+**`רקע רפואי` section (MANDATORY — admission and discharge):**
+Appears immediately after diagnosis lists. Per-system/per-disease narrative expansion of background conditions. Use organ-based headers with dash: `לבבי -`, `GI -`, `זיהומי -`, `ניתוחים/פעולות:`. Describe each condition briefly in 1-3 sentences — treatment, severity, relevant history. This section always appears in real SZMC documents and must never be omitted.
+
+**Labs format note:** The physician **does** write labs in the note as **inline prose** in the `בדיקות מעבדה` section, plus imaging findings in `בדיקות עזר`. The tabular lab display with reference ranges seen in printouts is auto-generated by the SZMC EMR — that table is never written manually. Write all labs as flowing prose:
+
+`כימיה: נתרן 136, אשלגן 3.6, קריאטינין 1.19, BUN 21, CRP 9.29, eGFR 59.`
+`ספירה: לויקוציטים 21.9, ניוטרופילים 87.7%, המוגלובין 12.7, טסיות 289 (אלפים).`
+`קואגולציה: INR 1.22, פיברינוגן 640.`
+`גזים: PH 7.44, PCO2 39, HCO3 26.5, לקטט 1.2.`
+
+Imaging (אקג, צ"ח, CT, US, אקו לב) always written in `בדיקות עזר` as free prose per modality.
+
+**`המשך טיפול תרופתי` (discharge):**
+Separate section from `תרופות בבית`. Contains the discharge prescription list — medications the patient takes home. Format: numbered list, SZMC medication format. Distinct from in-hospital medications (`תרופות באשפוז`).
+
+**`תרופות באשפוז` format:** `DD/MM/YY HH:MM  [DRUG] [DOSE]` — one per line with timestamp prefix.
+
+**`מהלך ודיון` in ED discharge:** Does NOT use `#` problem headers — that is ward-only. Two real styles:
+Style 1 (`במיון- / לסיכום-`): Used for longer ED stays/observation. Opens with `במיון —` (exam, labs, imaging as prose lines), then `לסיכום —` (clinical decision and disposition).
+Style 2 (bare lines): Used for short visits. Each line is a finding, impression, or decision. No connectors, no headers.
+
+**Urinary catheter:** If a urinary catheter was inserted on or during admission, add as a diagnosis entry: `URINARY CATHETERIZATION — inserted DD/MM/YY`. If the reason was retention, add: `URINARY RETENTION — [X] ml at presentation`. Both go in the active diagnoses list.
+
+**Blood transfusion:** If patient received transfusions, add as diagnosis: `BLOOD TRANSFUSION — [N] units pRBC` (with date if relevant). Goes in active diagnoses list.
+
+
+
+**Functional status (geriatrics):** Pick ONE value per field, never list options with slashes.
+
+## LANGUAGE RULES
+
+- **Diagnoses**: English always
+- **Narrative**: Hebrew
+- **Drug names**: Generic English + brand Hebrew in parentheses
+- **Abbreviations**: יל"ד, ל"ד, כ"א, דו"צ, מ/א, ע"ר, א"ח, בא"ח, NC, מלר"ד
+- **Gender agreement** throughout Hebrew text
+- **No bullet points** in narrative — flowing prose only
+
+## GERIATRIC REQUIREMENTS
+
+For גריאטריה -מח / גריאטריה מוגבר notes, mandatory items:
+1. Functional baseline (pre-morbid AND current)
+2. Mobility aid, cognitive status, caregiver, living situation
+3. Padua score, delirium assessment if relevant
+4. Code status (DNR/DNI) if discussed
+5. PT/OT referral noted
+
+## GERIATRIC ANALYSIS
+
+**Read `references/geriatric-analysis.md` for full framework.**
+
+Auto-run for geriatric ward notes. Skip if user says "בלי ניתוח" or "just the note".
+
+Show in chat after note (NOT in EMR output):
+```
+ניתוח גריאטרי — {patient}
+[Critical — immediate action]
+[Warning — this admission]
+[Missing workup / assessment]
+[Teaching point]
+```
+Max 10-12 flags. Covers: Beers 2023, STOPP/START, drug interactions, anticholinergic burden, renal dosing, nutrition, falls, delirium, VTE, code status, missing labs/assessments.
+
+## HTML EXPORT
+
+Always generate an HTML file alongside the chat output. Purpose: user emails to self, opens on phone, copies each section into EMR fields with correct RTL.
+
+**Requirements:**
+- `dir="rtl"` on html and all containers, `unicode-bidi: embed; direction: rtl;` on text
+- Font: David for Hebrew, Calibri fallback
+- Each EMR section in a separate `<div class="section">` with label and content
+- English medical terms wrapped in `<span dir="ltr" style="direction:ltr;unicode-bidi:embed;">` to prevent RTL reordering
+- `white-space: pre-wrap` on content divs
+- No geriatric analysis in HTML (stays in chat only)
+- File naming: `kabala_{last}_{first}_{date}.html` or `shichrur_{last}_{first}_{date}.html`
+- Save to `/mnt/user-data/outputs/` and present via `present_files`
+
+## QUALITY CHECKS
+
+Before output, verify:
+- [ ] All diagnoses in English
+- [ ] `רקע רפואי` section present with per-system narrative
+- [ ] Medications in SZMC format (`תרופות באשפוז` with timestamps; `המשך טיפול תרופתי` for discharge Rx)
+- [ ] Padua score included (end of מחלה נוכחית)
+- [ ] Problem-based `#` discussion (ward notes) or short narrative (ED discharge)
+- [ ] No bullet points in narrative sections
+- [ ] Gender agreement in Hebrew
+- [ ] O2 delivery method documented
+- [ ] Functional status complete (geriatric notes)
+- [ ] HTML file generated with RTL
+- [ ] Geriatric analysis shown in chat
+- [ ] Consultant recommendations documented when present
+- [ ] CHADS2/CHA2DS2-VASc included if AF present
+- [ ] Goals-of-care reasoning documented for complex/frail patients
+- [ ] Anticoagulation hold/bridge plan documented if applicable
+
+## SZMC DEPARTMENTS
+
+- `גריאטריה -מח` — Geriatrics ward
+- `גריאטריה מוגבר` — Geriatrics enhanced
+- `רפואה דחופה-מיון` — ED
+- `רפואה פנימית` — Internal medicine
+
+---
+
+## REAL-WORLD EXAMPLES — PATTERNS FROM ACTUAL SZMC NOTES
+
+The following patterns are extracted from real SZMC geriatric ward admission notes and interim discharge summaries. Use these as authoritative style/structure references when generating notes. They demonstrate the exact voice, phrasing, section ordering, and clinical reasoning style used by SZMC geriatrics physicians.
+
+### EXAMPLE A: Geriatric Admission — Suspected Seizure + Aspiration Pneumonia + AKI (Male, 84)
+
+**הצגת החולה:**
+```
+בן 84, הגיע מרפואה דחופה-מיון, מקור מידע בן/בת, מתגורר בבית
+```
+
+**תלונה עיקרית:**
+```
+חשד לפרכוס
+```
+
+**רקע רפואי — per-system format (note the dash headers):**
+```
+מחלות:
+לבבי -
+לפני 10 שנים ניתוח לב פתוח בקנדה עם החלפת מסתם אאורטלי מכני וCABG.
+תחת סטטינים, ואספירין
+GI-
+דימום בעברו, על כן תחת PPI.
+BPH-
+תחת טמסולין.
+זיהומי-
+אושפז במוסדנו ב2.25 עם אנדוקרדיטיס, טופל אנטיביוטית דרך PICCLINE
+פרוט ניתוחים/פעולות:
+CABG
+החלפת מסתם אאורטלי - לא ברור סוג
+```
+
+**מחלה נוכחית — narrative style:**
+```
+בן 84, במקור מדרום אפריקה ומתגורר בקנדה ובישראל, נשוי מתגורר עם אשתו, סיעודי עם דמנציה, יש עובדת זרה.
+ברקע BPH, IHD, דיליפידמיה, עבר לפני 10 שנים CABG + החלפת מסתם אאורטלי (ביולוגי).
+סיפור של ירידה כללית עם כותרת של דמנציה. לדברי אשתו הולך עם הליכון בבית. בשנים האחרונים ירידה ניכרת בתאבון ובמשקל.
+ביום קבלתו חולשה כללית ניכרת, סירב ללכת עם הילכון, בהמשך אירוע של סטיית מבט וחוסר תקשורת שנמשך כ20 דקות. קיבל דורמיקום ממדא ולאחריו הפסקה. ללא תנועות טוני קלונוית. כמו כן קיבל אקמול ונוזלים לאור חום וטכיקרדיה. ללא סיפור של שיעול במהלך האכילה, ללא תלונות נוספות.
+```
+
+**ED workup embedded in narrative (before ward admission):**
+```
+בבדיקתו ללא מקור ברור לחום
+מעבדה-נוירטופיליה.
+אנמיה נורמוציטי 9 (ירידה מבדיקה קודמת)
+קריאטינין 1.7 החמרה מבסיס
+עליה במדדי דלקת
+צילום-ללא הצללה ברורה
+CT ראש-ללא ממצאים
+לאור חום ממקור לא ברור ואירוע של סטיית מבט הושלם LP. כמו כן קיבל כיסוי אנטיביוטי
+אושפז בגריאטריה להמשך בירור וטיפול
+```
+
+**בקבלתו למחלקה — vitals + focused exam:**
+```
+סימנים חיוניים: לחץ דם 124/68, דופק 112, ללא חום
+שקוע, TEMPORAL WASTING, חלש מאוד
+לב סדיר ללא אוושות
+ראות כניסת אוויר ירודה משמאל, ללא צפצופים
+בטן רכה ללא רגישות
+גפיים ללא בצקות או סימני צלוליטיס
+```
+
+**Problem-based discussion with # headers:**
+```
+# זהומית: מטופל עם רקע של דמנציה, לאחרונה החמרה בחולשה, נזקק לכ"ג. ביום קבלתו חום עד 38. בבדיקתו כניסת אוויר ירודה משמאל, במעבדה עליה קלה בCRP, בצילום חזה תסנין בLLL- ככל הנראה מדובר באספירציה - הוחל טיפול אנטיביוטי בCEFTRIAXONE.
+- בחשד למנינגיטיס עקב החמרה הכרתית, בוצע CT מוח ללא ממצא, ניקור מותני בצורה סטירילית כמקובל בשעה 0430 בדקירה אח, יצא נוזל צלול ושקוף, ל.פ. 6 ס"מ מים, נלקחו 5 מבחנות, נשלחו כימיה, תרביות, ספירה ו2 מבחנות לשמירה.
+**לציין קיבל צפטריאקסון טרם ה-LP.
+# נוירולוגית: מטופל עם רקע של דמנציה, התקבל בשל חשד לפרכוס. CT מוח תקין, LP ללא ממצא. ייתכן ע"ר מטבולי- נשלים EEG מחר. בינתיים ללא צורך בהתחלת טיפול נגד פרכוסים
+# AKI: מטופל עם קריאטינין בסיס תקין, כעת התקבל עם החמרה כלייתית עם קריאטינין עד 1.4 עם BUN 24. ככל הנראה מדובר בATN. נתחיל טיפול בנוזלים ונחזור על מעבדה מחר. נשלים שתן למיקרוסקופיה.
+# תפקודית: מטופל הולך עם הליכון עד לפני יומיים, נזמין הערכת פיזיותרפיה.
+```
+
+**תוכנית — bare verb list:**
+```
+IV ABX
+IV נוזלים
+שתן למיקרוסקופיה
+EEG
+```
+
+### EXAMPLE B: ED Admission — Cholecystitis (Female, 92)
+
+**תלונה עיקרית (ED style — brief, one-liner):**
+```
+בת 92, ברקע יל"ד, סוכרת, אפלפסיה. מתהלכת בעזרת הליכון.
+כשעה טרם קבלתה החלה לסבול מכאבים בחזה אינם מקרינים, לא קשורים לנשימה. ללא בחילות או הקאות. ללא חום.
+לדברי בנה מיום טרם קבלתה חלשה.
+לא ידועה על כאבים בחזה מלפני.
+כעת במיון מתלוננת על כאבים בבטן ימנית עליונה
+```
+
+**בדיקות עזר (US at bedside):**
+```
+א.ס- ללא הידרונפרוזיס דו"צ, ללא נוזל חופשי בבטן, כיס מרה מכיל אבנים מרובים, יתכן עיבוי דופן. מרפי סונוגרפי חיובי.
+```
+
+**ED discussion with # headers (note: this is an ED-to-ward admission, NOT a pure ED discharge — so # headers ARE used):**
+```
+במהלך שהותה במיון מצייגה את הבעיות הבאות:
+# לבבית- מטופלת ללא רקע של מחלות לב התקבלה לאחר כאבים בחזה, אקג תקין, טרופונין שלילי וצל"ח ללא ממצא חריג לציין. ייתכן שכאב חזה ללא מקור לבבי.
+# גסטרו- בבדיקתה רגישות בבטן ימנית עליונה עם מדדי דלקת מוגברים, בא"ס ליד המיטה ניראה כיס המרה מכיל אבנים מרובים עם מרפי סונוגרפי חיובי. ייתכן שמדובר על CHOLECYSTITIS. במיון קיבלה נוזלים והחלה טיפול א"ב
+```
+
+### EXAMPLE C: Geriatric Admission — Hypernatremic Dehydration + Dysphagia (Male, 94)
+
+**הצגת החולה — note the community physician detail:**
+```
+הגיע מרפואה דחופה-מיון, בן 94, גרוש, אב לילד אחד, מתגורר לבד בדיור מוגן.
+פרטי רופא בקהילה: שם רופא: ד"ר בוריס מוהירמן, סניף: קופ"ח מכבי
+```
+
+**רקע רפואי — using # markers per disease:**
+```
+מחלות:
+# HYPOTHYROIDISM
+נוטל EUTHYROX.
+TSH אחרון (16/01/22): 3.58
+# IHD
+כותרת מ"אופק". נוטל סטטינים ואספירין.
+# יל"ד
+נוטל LERCAPRESS
+# BPH
+# היפונתרמיה
+כותרת מבדיקת אנדוקרינולוג בקהילה. ב"אופק" ערכים בין 127 ל135)
+ניתוחים/פעולות:
+# ROTATOR CUFF SYNDROME RT. S/P SUPRASCAPULAR NERVE BLOCK
+```
+
+**מחלה נוכחית — with prior ED visit referenced:**
+```
+בן 94, הידרדרות קוגנטיבית, גר לבד, נעזר על יד מטב"ים למספר שעות ביממה.
+ברקע יתר ל"ד, מחלת לב איסכמית, BPH משתמש בקטטר קבוע, היפותאירואידיזם, היפרליפידימיה.
+פניה רצנטית למיון בשל הידרדרות כללית ונפילה וחבלת ראש שבועיים טרם קבלתו כעת
+במיון אז נעשה CT מוח
+ללא ממצא אינטרה-קרניאלי חד בבדיקה זו ובפרט ללא דימום או בצקת מוחית.
+שינויים מוחיים איסכמיים ומיקרווסקולופתיים כרוניים.
+טופל בנוזלים עם רושם להטבה, כמו כן הוחלף קטטר שתן עם הטבה ביציאת השתן לאחר מכן.
+כעת חזר למיון עקב מיעוט באכילה ושתייה במידה רבה עד שבימים אחרונים כמעט לא אכל או שתה. הבן מסביר כי המטופל התלונן על קשיי בליעה ללא פירוט נוסף וכי הם הגורם לצמצום המשמעותי.
+```
+
+**תפקוד — full ADL assessment (geriatric mandatory):**
+```
+מגורים: מתגורר בבית
+עזרה: מט"ב - מספר שעות: 10
+ניידות: הולך בעזרת הליכון
+התמצאות: ירידה קוגניטיבית קלה
+הלבשה: עזרה מלאה
+רחצה: עזרה מלאה
+אכילה: עזרה חלקית
+הכנת אוכל: עזרה מלאה
+ניידות: עזרה מלאה
+מעברים: עזרה מלאה
+שליטה על שתן: עזרה חלקית
+שליטה על יציאה: עזרה חלקית
+הזנה: כלכלה רגילה פומית
+```
+
+**בדיקה גופנית — with POCUS:**
+```
+הופעה כללית: ל"ד 176/69, דופק 68, חום 36.4 PO, סטורציה 97% באוויר חדר, נלקח 23:49 01/03
+מצב כללי: טוב, לא מתמצא 3X ללא מצוקה נשימתית, ללא כחלון צהבת חיווורון. קכקטי.
+פה ולוע: ריריות יבשות.
+ריאות: ריאות: טכיפנאי, כניסת אוויר טובה דו"צ, ללא חירחורים או ציפצופים
+לב: קצב סדיר, אין איוושות
+בטן: רכה ללא רגישות
+גפיים: אין פגמים או סימני דלקת במפרקים, אין דליות בצקת אודם או כחלון
+```
+
+**בדיקות עזר:**
+```
+אק"ג- לא סדיר, רושם ל- atrial flutter ול- PVC.
+צל"ח- ללא תפילטים ללא תסנינים.
+POCUS- בדיקת IVC, כ- 2 ס"מ, קריסה של כ- 50%.
+```
+
+**דיון ותוכנית — with goals-of-care embedded:**
+```
+[...clinical summary...]
+רושם להתייבשות קשה וירידה במשקל בחודשים האחרונים
+החמרה כלייתית על רקע התייבשות
+זקוק להערכת בליעה ונוזלים ודיון עם המשפחה אם מעוניינים בהמשך בירור ובמידת האפשר הכנסת זונדה / PEG אמבולטורי.
+תוכנית:
+נוזלים
+קלינאית תקשורת
+בירור בליעה
+מעקב התייבשות
+TSH
+איזון ל"ד
+```
+
+### EXAMPLE D: Geriatric Admission — Esophageal Dysphagia Workup (Male, 75)
+
+**רקע רפואי — with detailed prior hospitalization summaries:**
+```
+מחלות:
+# ביתו סובלת מLUPUS.
+# לפני 6 שנים טרם כליה לביתו.
+#אשפוז בפנימית א ב3/2025 עקב ASTHMA EXACERBATION
+במהלך אשפוזו בשל ממצאים ב CT, עבר הערכת רופא ריאות:
+1. ללא עדות לתסחיף ריאתי מרכזי או פריפרי ברור.
+2. ב-RUL הצללה זכוכית חול קלושה - ללא שינוי ביחס לבדיקה מה-18.07.17 - באבחנה מבדלת שינויים כרוניים / תהליך נאופלסטי (סרטן מסוג צמיחה ליפידית עם גדילה איטית).
+3. עיבוי דופנות סימפונות דו צדדי. מעט תוכן בסימפונות.
+[...pulmonologist recommendations quoted...]
+אשפוז בקרדיולוגיה ב2017
+עקב נפיחות ברגל ימין, בבירור עלה שמדובר ב DVT ברגל ימין, עבר מיפוי ריאות עם שלא הדגים PE
+אקו לב הדגים תפקוד שמור של חדר שמאל,
+RV Mildly dilated with impaired contraction
+[...echo findings, CT-A findings, risk stratification, DOAC initiation...]
+```
+
+**Consultant recommendations embedded in plan:**
+```
+בייעוץ גסטרו הומלץ על השהיית אלקויס ולהתקדם יום שלישי לבדיקת גסטרוסקופיה באשפוז לאחר 48 שעות השהייה של אלקוויס
+הומלץ על ידי גסטרו להשלים CT חזה + CT בטן-אגן
+```

--- a/.agents/skills/source-command-toranot-update-skill/SKILL.md
+++ b/.agents/skills/source-command-toranot-update-skill/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: "source-command-toranot-update-skill"
+description: "Auto-update SKILL.md (toranot-dev) with current ground truth. Run after every deploy or when skill feels stale."
+---
+
+# source-command-toranot-update-skill
+
+Use this skill when the user asks to run the migrated source command `toranot-update-skill`.
+
+## Command Template
+
+You are updating the toranot-dev SKILL.md file to reflect current ground truth.
+Do NOT make any code changes. Only update the skill file.
+
+## STEP 1 — Pull live state from snapshot endpoint
+```
+GET https://toranot.netlify.app/api/skill-snapshot
+# Direct path equivalent: /.netlify/functions/skill-snapshot
+```
+Extract: patientCount, lastStateUpdate, backupCount, errorCount, health status.
+If endpoint is down, proceed with manual checks.
+
+## STEP 2 — Manual verification (always run)
+```bash
+# Test count
+npx vitest run 2>&1 | grep -E "passed|failed"
+
+# Test file count
+ls src/__tests__/*.test.ts | wc -l
+
+# Bundle size
+npx vite build 2>&1 | grep "dist/index" | grep -oP '\d+\.\d+ kB'
+
+# Rules count
+grep -c "group:" src/engine/rules.ts
+
+# Component count
+ls src/components/*.tsx | wc -l
+
+# Current package version
+cat package.json | grep '"version"'
+
+# TypeScript clean
+npx tsc --noEmit && echo "TS: clean" || echo "TS: ERRORS"
+```
+
+## STEP 3 — Update SKILL.md
+
+Patch exactly these fields (leave everything else untouched):
+
+| Field | Location in skill | Source |
+|-------|------------------|--------|
+| Test count | §1 Overview table + §9 Gotchas | vitest run output |
+| Test file count | §1 Overview table | ls count |
+| Bundle size | §1 Overview table | vite build output |
+| Rules count | §4 engine section | grep count |
+| Component count | §1 repo structure | ls count |
+| Last audited date | Top of relevant section | today's date |
+
+## STEP 4 — Commit via branch + PR (single-lane AGENTS.md)
+```bash
+git add SKILL.md 2>/dev/null || true
+# If skill file is in project knowledge, note the updates needed manually
+if ! git diff --cached --quiet; then
+  # Branch name uses full date+time AND short HEAD sha. The HHMMSS
+  # component guarantees uniqueness on reruns (the prior date-only +
+  # short_sha pattern still collided when HEAD had not moved between
+  # the failed run and its retry — Codex P1 on PR #99). Two runs would
+  # have to fire in the same wall-clock second to collide.
+  short_sha=$(git rev-parse --short HEAD)
+  git checkout -b "Codex/skill-currency-$(date +%Y%m%d-%H%M%S)-${short_sha}"
+  git commit -m "docs: auto-update toranot skill $(date +%Y-%m-%d) [skip ci]"
+  git push -u origin HEAD
+  gh pr create --base main \
+    --title "docs: refresh skill currency $(date +%Y-%m-%d)" \
+    --body "Auto-opened by /toranot-update-skill. Docs-only, no source changes."
+fi
+```
+Per audit-fix-deploy SKILL § D.5, this docs-only PR is eligible for self-merge
+after Codex green (or after a meaningful Codex absence with override rationale).
+
+If nothing changed, say "Skill file already up to date — no commit needed."
+
+## IMPORTANT NOTES
+- Hebrew files may contain invisible U+200F characters — use Python subprocess for str_replace if tool fails
+- Never modify clinical rule logic or drug safety logic in this command — read-only skill update only
+- If test count changed, verify reason before updating — unexpected change = possible regression

--- a/.agents/skills/toranot-ship/SKILL.md
+++ b/.agents/skills/toranot-ship/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: toranot-ship
+description: End-to-end Toranot ship pipeline. Runs the mandatory 7-step workflow (tsc, vitest, vite build, README update, git push with PAT rotation, Netlify deploy verification, auditor sweep). Use when user says "push", "push Toranot", "deploy", "ship Toranot", "ship it", "release", or any variant asking to ship Toranot to production. DO NOT use for watch-advisor2 or Shlav A Mega — this is Toranot-specific.
+disable-model-invocation: true
+---
+
+# Toranot Ship Pipeline
+
+Single-command production ship for `github.com/Eiasash/Toranot` → `toranot.netlify.app`.
+
+This skill is **user-invokable only** — Codex will not auto-run it, because it pushes to production and touches a live PAT.
+
+## Preconditions (ask the user if unclear)
+
+1. Working tree is in the Toranot repo root (usually `/home/Codex/Toranot`).
+2. User has provided a **fresh GitHub PAT** for this session. Never store it. Paste into the `$GH_PAT` environment variable only.
+3. There are real, staged or unstaged changes worth shipping (`git status` not clean).
+4. User has edited the `README.md` Recent Changes section OR authorized this skill to add a terse one-liner.
+
+If any precondition is unmet, stop and ask.
+
+## Pipeline (Strict Order)
+
+Each step MUST pass before the next runs. On any failure: stop, surface the exact error, and do not proceed.
+
+### Step 1 — TypeScript gate
+```
+npx tsc --noEmit
+```
+Zero errors required. No suppressions.
+
+### Step 2 — Full vitest suite
+```
+npx vitest run --reporter=dot
+```
+All 2271 tests across 72 files must pass (last audited: 2026-05-01). If a new test was added, the new count is fine — but it must match the README/AGENTS.md claim (update both in the same commit if the number moves).
+
+### Step 3 — Production build + bundle gate
+```
+npx vite build
+```
+Then assert main bundle stays under 150KB:
+```
+bash scripts/preflight.sh --bundle-gate
+```
+(Falls back to `du -sb dist/assets/index-*.js | awk '{ if ($1 > 153600) exit 1 }'`.)
+
+### Step 4 — README touch-up
+If the user did not update `README.md` Recent Changes, prompt for a one-line entry:
+```
+- YYYY-MM-DD: <short summary> (<short hash will go here>)
+```
+Commit it in the same commit as the feature.
+
+### Step 5 — Push with PAT rotation
+Uses `scripts/push-with-pat.sh`:
+1. `git remote set-url origin https://$GH_PAT@github.com/Eiasash/Toranot.git`
+2. `git config user.email "eias@toranot.app"`
+3. `git config user.name "Eias"`
+4. `git add -A && git commit -m "<type>: <description>" && git push origin main`
+5. **Immediately** `git remote set-url origin https://github.com/Eiasash/Toranot.git` (scrubs PAT)
+6. Print reminder: `Revoke at https://github.com/settings/tokens`
+
+Commit message convention: `feat:`, `fix:`, `refactor:`, `test:`, `chore:`, `docs:`.
+
+### Step 6 — Netlify deploy verification
+Uses `scripts/verify-deploy.sh`:
+- Poll `https://api.netlify.com/api/v1/sites/85d12386-b960-4f65-bee8-80e210ecd683/deploys?per_page=1`
+- Wait up to 5 minutes. State progression: `uploading → building → ready`.
+- On `ready`: assert `commit_ref` matches the just-pushed SHA.
+- On `error`: surface the build log URL, stop, do NOT mark success.
+
+### Step 7 — Post-deploy audit sweep
+Delegate to the `toranot-auditor` subagent with a fresh context. It checks:
+- Dismissed tasks leaking into aggregations
+- `RULES.length` assertion still matches `rules.ts`
+- Banned patterns (`transition-all`, `confirm()`, mid-file imports, `will-change` on `animate-card-in`)
+- `console.log` leaks
+- Test count drift between README/AGENTS.md and actual vitest output
+- Bundle size still <150KB on the deployed build
+
+If the auditor flags anything, surface it as a follow-up — do not auto-fix on the same ship.
+
+## Failure modes + recovery
+
+| Failure | Action |
+|---------|--------|
+| tsc errors | Stop. Surface errors. Do NOT skip. |
+| vitest fails | Stop. Surface failing test names. Do NOT skip. |
+| Bundle >150KB | Stop. Run `npx vite-bundle-visualizer` or check lazy() coverage. |
+| Push rejected (non-fast-forward) | `git pull --rebase origin main`, resolve, retry. Never force-push `main`. |
+| Netlify stuck `building` >5 min | Trigger retry via Netlify MCP, re-poll. |
+| Netlify `error` | Fetch build logs, surface to user, do NOT declare success. |
+| Auditor findings | Surface as a `toranot-followups.md` note. User decides whether to ship a follow-up. |
+
+## Never do
+
+- Never `git push --force` to `main`.
+- Never leave the PAT in the git remote — always scrub immediately after push.
+- Never skip steps 1–3 to "just get it out".
+- Never edit `sw.js` `CACHE_VERSION` manually — Vite plugin stamps it.
+- Never merge changes that edited 1-of-5 room-format files without the other 4 (see `hooks/room-format-drift.js`).

--- a/.agents/skills/toranot-ship/SKILL.md
+++ b/.agents/skills/toranot-ship/SKILL.md
@@ -41,7 +41,7 @@ npx vite build
 ```
 Then assert main bundle stays under 150KB:
 ```
-bash scripts/preflight.sh --bundle-gate
+bash .agents/skills/toranot-ship/scripts/preflight.sh --bundle-gate
 ```
 (Falls back to `du -sb dist/assets/index-*.js | awk '{ if ($1 > 153600) exit 1 }'`.)
 
@@ -52,19 +52,23 @@ If the user did not update `README.md` Recent Changes, prompt for a one-line ent
 ```
 Commit it in the same commit as the feature.
 
-### Step 5 — Push with PAT rotation
-Uses `scripts/push-with-pat.sh`:
-1. `git remote set-url origin https://$GH_PAT@github.com/Eiasash/Toranot.git`
-2. `git config user.email "eias@toranot.app"`
-3. `git config user.name "Eias"`
-4. `git add -A && git commit -m "<type>: <description>" && git push origin main`
+### Step 5 — Branch-push with PAT rotation + PR
+Uses `.agents/skills/toranot-ship/scripts/push-with-pat.sh`. It NEVER pushes
+`main` directly — the release path is branch → PR → CI green + Codex review →
+merge (AGENTS.md):
+1. Resolves the ship branch: reuses the current non-main branch, or creates
+   `codex/ship-<utc-stamp>` when invoked from `main`. Refuses `main` outright.
+2. `git remote set-url origin https://$GH_PAT@github.com/Eiasash/Toranot.git`
+3. `git config user.email "eias@toranot.app"` + `git config user.name "Eias"`
+4. `git add -A && git commit -m "<type>: <description>" && git push -u origin <ship-branch>`
 5. **Immediately** `git remote set-url origin https://github.com/Eiasash/Toranot.git` (scrubs PAT)
-6. Print reminder: `Revoke at https://github.com/settings/tokens`
+6. Opens the PR via `gh pr create` (or prints the compare URL if `gh` is unavailable)
+7. Print reminder: `Revoke at https://github.com/settings/tokens`
 
 Commit message convention: `feat:`, `fix:`, `refactor:`, `test:`, `chore:`, `docs:`.
 
-### Step 6 — Netlify deploy verification
-Uses `scripts/verify-deploy.sh`:
+### Step 6 — Netlify deploy verification (after the PR merges)
+Uses `.agents/skills/toranot-ship/scripts/verify-deploy.sh`:
 - Poll `https://api.netlify.com/api/v1/sites/85d12386-b960-4f65-bee8-80e210ecd683/deploys?per_page=1`
 - Wait up to 5 minutes. State progression: `uploading → building → ready`.
 - On `ready`: assert `commit_ref` matches the just-pushed SHA.

--- a/.agents/skills/toranot-ship/scripts/preflight.sh
+++ b/.agents/skills/toranot-ship/scripts/preflight.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Toranot preflight: tsc → vitest → vite build → bundle size gate.
+# Exit codes:
+#   0 = all gates passed
+#   1 = tsc failed
+#   2 = vitest failed
+#   3 = vite build failed
+#   4 = bundle size gate failed
+#
+# Usage:
+#   bash .claude/skills/toranot-ship/scripts/preflight.sh          # full preflight
+#   bash .claude/skills/toranot-ship/scripts/preflight.sh --bundle-gate   # only the bundle gate
+set -euo pipefail
+
+BUNDLE_BUDGET_BYTES=${BUNDLE_BUDGET_BYTES:-153600}  # 150 * 1024
+
+bundle_gate() {
+  local max_size
+  if [[ ! -d dist ]]; then
+    echo "[preflight] no dist/ yet — run vite build first" >&2
+    return 4
+  fi
+  # Find the largest JS chunk (the main bundle), ignoring pre-gzipped .gz/.br
+  max_size=$(find dist/assets -name 'index-*.js' -not -name '*.gz' -not -name '*.br' -printf '%s\n' 2>/dev/null | sort -nr | head -1)
+  if [[ -z "$max_size" ]]; then
+    echo "[preflight] could not find dist/assets/index-*.js" >&2
+    return 4
+  fi
+  if (( max_size > BUNDLE_BUDGET_BYTES )); then
+    printf "[preflight] bundle %d bytes exceeds budget %d bytes\n" "$max_size" "$BUNDLE_BUDGET_BYTES" >&2
+    return 4
+  fi
+  printf "[preflight] bundle %d bytes OK (budget %d)\n" "$max_size" "$BUNDLE_BUDGET_BYTES"
+  return 0
+}
+
+if [[ "${1:-}" == "--bundle-gate" ]]; then
+  bundle_gate
+  exit $?
+fi
+
+echo "[preflight] step 1/4 — tsc --noEmit"
+if ! npx tsc --noEmit; then
+  echo "[preflight] tsc failed — fix type errors before shipping" >&2
+  exit 1
+fi
+
+echo "[preflight] step 2/4 — vitest run"
+if ! npx vitest run --reporter=dot; then
+  echo "[preflight] vitest failed — fix broken tests before shipping" >&2
+  exit 2
+fi
+
+echo "[preflight] step 3/4 — vite build"
+if ! npx vite build; then
+  echo "[preflight] vite build failed" >&2
+  exit 3
+fi
+
+echo "[preflight] step 4/4 — bundle size gate"
+bundle_gate || exit 4
+
+echo "[preflight] OK — safe to push"

--- a/.agents/skills/toranot-ship/scripts/push-with-pat.sh
+++ b/.agents/skills/toranot-ship/scripts/push-with-pat.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
-# Safe push to Eiasash/Toranot with PAT rotation.
+# Safe branch-push to Eiasash/Toranot with PAT rotation.
 # The PAT is injected into the remote URL only for the push, then scrubbed
 # back to a tokenless HTTPS URL IMMEDIATELY — even on failure.
 #
+# Ships via the AGENTS.md release path: branch -> PR -> CI green + Codex
+# review -> merge. This script NEVER pushes main directly.
+#
 # Usage:
-#   GH_PAT=ghp_xxx bash .claude/skills/toranot-ship/scripts/push-with-pat.sh "feat: description"
+#   GH_PAT=ghp_xxx bash .agents/skills/toranot-ship/scripts/push-with-pat.sh "feat: description" [branch-name]
+#
+# If branch-name is omitted and HEAD is on main, a codex/ship-<utc-stamp>
+# branch is created. If HEAD is already on a non-main branch, it is reused.
 #
 # Fails (non-zero exit) if:
 #   - GH_PAT is unset
 #   - commit message is missing
-#   - branch is not main
+#   - the resolved ship branch is main
 #   - push fails
 #
 # On any exit path, scrub the remote.
@@ -41,15 +47,31 @@ if ! [[ "$COMMIT_MSG" =~ ^(feat|fix|refactor|test|chore|docs|perf|style)(\(.+\))
   exit 12
 fi
 
-CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$CUR_BRANCH" != "main" ]]; then
-  echo "[push] refusing to ship from branch '$CUR_BRANCH' — switch to main first" >&2
-  exit 13
-fi
-
 if [[ -z "$(git status --porcelain)" ]]; then
   echo "[push] nothing to commit — working tree clean" >&2
   exit 14
+fi
+
+CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SHIP_BRANCH="${2:-}"
+if [[ -z "$SHIP_BRANCH" ]]; then
+  if [[ "$CUR_BRANCH" == "main" ]]; then
+    SHIP_BRANCH="codex/ship-$(date -u +%Y%m%d-%H%M%S)"
+  else
+    SHIP_BRANCH="$CUR_BRANCH"
+  fi
+fi
+
+if [[ "$SHIP_BRANCH" == "main" ]]; then
+  echo "[push] refusing to push main directly — release path is branch -> PR -> CI + Codex review -> merge (AGENTS.md)" >&2
+  exit 13
+fi
+
+if [[ "$CUR_BRANCH" != "$SHIP_BRANCH" ]]; then
+  if ! git checkout -b "$SHIP_BRANCH"; then
+    echo "[push] could not create branch $SHIP_BRANCH" >&2
+    exit 17
+  fi
 fi
 
 git config user.email "$COMMITTER_EMAIL"
@@ -64,11 +86,23 @@ if ! git commit -m "$COMMIT_MSG"; then
   exit 15
 fi
 
-if ! git push origin main; then
+if ! git push -u origin "$SHIP_BRANCH"; then
   echo "[push] push failed — remote is scrubbed via trap; resolve and retry" >&2
   exit 16
 fi
 
+scrub_remote
+
 SHA=$(git rev-parse --short HEAD)
-echo "[push] OK — pushed $SHA to main"
+echo "[push] OK — pushed $SHA to $SHIP_BRANCH"
+
+# Open the PR (gh if authenticated, otherwise print the compare URL)
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  gh pr create --base main --head "$SHIP_BRANCH" --title "$COMMIT_MSG" \
+    --body "Shipped via toranot-ship. Merge requires CI green + Codex review per AGENTS.md." \
+    || echo "[push] gh pr create failed — open manually: https://github.com/Eiasash/Toranot/compare/main...$SHIP_BRANCH" >&2
+else
+  echo "[push] open the PR: https://github.com/Eiasash/Toranot/compare/main...$SHIP_BRANCH"
+fi
+
 echo "[push] REMINDER: revoke this PAT at https://github.com/settings/tokens"

--- a/.agents/skills/toranot-ship/scripts/push-with-pat.sh
+++ b/.agents/skills/toranot-ship/scripts/push-with-pat.sh
@@ -12,10 +12,15 @@
 # If branch-name is omitted and HEAD is on main, a codex/ship-<utc-stamp>
 # branch is created. If HEAD is already on a non-main branch, it is reused.
 #
+# Resume: if a previous run committed but the push failed, rerun the same
+# command from the ship branch — unpushed commits are detected and re-pushed
+# (no new commit is created when the tree is clean).
+#
 # Fails (non-zero exit) if:
 #   - GH_PAT is unset
 #   - commit message is missing
 #   - the resolved ship branch is main
+#   - nothing to ship (clean tree AND no unpushed commits)
 #   - push fails
 #
 # On any exit path, scrub the remote.
@@ -47,11 +52,6 @@ if ! [[ "$COMMIT_MSG" =~ ^(feat|fix|refactor|test|chore|docs|perf|style)(\(.+\))
   exit 12
 fi
 
-if [[ -z "$(git status --porcelain)" ]]; then
-  echo "[push] nothing to commit — working tree clean" >&2
-  exit 14
-fi
-
 CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SHIP_BRANCH="${2:-}"
 if [[ -z "$SHIP_BRANCH" ]]; then
@@ -67,6 +67,19 @@ if [[ "$SHIP_BRANCH" == "main" ]]; then
   exit 13
 fi
 
+# Ship-needed check: dirty tree (fresh run) OR unpushed commits on the ship
+# branch (resume after a failed push — rerun from the ship branch itself).
+DIRTY=$(git status --porcelain)
+if git rev-parse --verify -q "origin/$SHIP_BRANCH" >/dev/null 2>&1; then
+  UNPUSHED=$(git rev-list --count "origin/$SHIP_BRANCH..HEAD" 2>/dev/null || echo 0)
+else
+  UNPUSHED=$(git rev-list --count "origin/main..HEAD" 2>/dev/null || echo 0)
+fi
+if [[ -z "$DIRTY" && "$UNPUSHED" -eq 0 ]]; then
+  echo "[push] nothing to ship — working tree clean and no unpushed commits" >&2
+  exit 14
+fi
+
 if [[ "$CUR_BRANCH" != "$SHIP_BRANCH" ]]; then
   if ! git checkout -b "$SHIP_BRANCH"; then
     echo "[push] could not create branch $SHIP_BRANCH" >&2
@@ -80,10 +93,14 @@ git config user.name "$COMMITTER_NAME"
 # Inject PAT ONLY for the push
 git remote set-url origin "https://${GH_PAT}@github.com/Eiasash/Toranot.git"
 
-git add -A
-if ! git commit -m "$COMMIT_MSG"; then
-  echo "[push] commit failed" >&2
-  exit 15
+if [[ -n "$DIRTY" ]]; then
+  git add -A
+  if ! git commit -m "$COMMIT_MSG"; then
+    echo "[push] commit failed" >&2
+    exit 15
+  fi
+else
+  echo "[push] resuming — re-pushing $UNPUSHED stranded local commit(s) on $SHIP_BRANCH"
 fi
 
 if ! git push -u origin "$SHIP_BRANCH"; then

--- a/.agents/skills/toranot-ship/scripts/push-with-pat.sh
+++ b/.agents/skills/toranot-ship/scripts/push-with-pat.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Safe push to Eiasash/Toranot with PAT rotation.
+# The PAT is injected into the remote URL only for the push, then scrubbed
+# back to a tokenless HTTPS URL IMMEDIATELY — even on failure.
+#
+# Usage:
+#   GH_PAT=ghp_xxx bash .claude/skills/toranot-ship/scripts/push-with-pat.sh "feat: description"
+#
+# Fails (non-zero exit) if:
+#   - GH_PAT is unset
+#   - commit message is missing
+#   - branch is not main
+#   - push fails
+#
+# On any exit path, scrub the remote.
+set -uo pipefail
+
+REPO_URL="https://github.com/Eiasash/Toranot.git"
+COMMITTER_NAME="Eias"
+COMMITTER_EMAIL="eias@toranot.app"
+
+scrub_remote() {
+  git remote set-url origin "$REPO_URL" 2>/dev/null || true
+}
+trap scrub_remote EXIT
+
+if [[ -z "${GH_PAT:-}" ]]; then
+  echo "[push] GH_PAT env var is required — paste your fresh PAT into the environment, do not commit it" >&2
+  exit 10
+fi
+
+COMMIT_MSG="${1:-}"
+if [[ -z "$COMMIT_MSG" ]]; then
+  echo "[push] commit message required as argument 1" >&2
+  exit 11
+fi
+
+# Enforce commit convention (feat:/fix:/refactor:/test:/chore:/docs:)
+if ! [[ "$COMMIT_MSG" =~ ^(feat|fix|refactor|test|chore|docs|perf|style)(\(.+\))?:\  ]]; then
+  echo "[push] commit message must start with type: — got: $COMMIT_MSG" >&2
+  exit 12
+fi
+
+CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CUR_BRANCH" != "main" ]]; then
+  echo "[push] refusing to ship from branch '$CUR_BRANCH' — switch to main first" >&2
+  exit 13
+fi
+
+if [[ -z "$(git status --porcelain)" ]]; then
+  echo "[push] nothing to commit — working tree clean" >&2
+  exit 14
+fi
+
+git config user.email "$COMMITTER_EMAIL"
+git config user.name "$COMMITTER_NAME"
+
+# Inject PAT ONLY for the push
+git remote set-url origin "https://${GH_PAT}@github.com/Eiasash/Toranot.git"
+
+git add -A
+if ! git commit -m "$COMMIT_MSG"; then
+  echo "[push] commit failed" >&2
+  exit 15
+fi
+
+if ! git push origin main; then
+  echo "[push] push failed — remote is scrubbed via trap; resolve and retry" >&2
+  exit 16
+fi
+
+SHA=$(git rev-parse --short HEAD)
+echo "[push] OK — pushed $SHA to main"
+echo "[push] REMINDER: revoke this PAT at https://github.com/settings/tokens"

--- a/.agents/skills/toranot-ship/scripts/verify-deploy.sh
+++ b/.agents/skills/toranot-ship/scripts/verify-deploy.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Poll Netlify API until the latest deploy for toranot.netlify.app is ready.
+# Asserts the deployed commit matches the just-pushed HEAD SHA.
+#
+# Usage:
+#   bash .claude/skills/toranot-ship/scripts/verify-deploy.sh
+#   NETLIFY_AUTH_TOKEN is optional — works without it (public site info),
+#   but authenticated polling gets higher rate limits.
+#
+# Exit codes:
+#   0 = deploy ready and commit_ref matches HEAD
+#   20 = timeout waiting for ready
+#   21 = deploy state = error
+#   22 = commit_ref mismatch
+set -euo pipefail
+
+SITE_ID="85d12386-b960-4f65-bee8-80e210ecd683"
+TIMEOUT_SEC=${TIMEOUT_SEC:-300}
+POLL_INTERVAL_SEC=${POLL_INTERVAL_SEC:-10}
+DEPLOYS_URL="https://api.netlify.com/api/v1/sites/${SITE_ID}/deploys?per_page=1"
+
+EXPECTED_SHA=$(git rev-parse HEAD)
+SHORT_SHA=${EXPECTED_SHA:0:7}
+echo "[verify] waiting for Netlify to deploy $SHORT_SHA …"
+
+AUTH_HEADER=()
+if [[ -n "${NETLIFY_AUTH_TOKEN:-}" ]]; then
+  AUTH_HEADER=(-H "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}")
+fi
+
+deadline=$(( $(date +%s) + TIMEOUT_SEC ))
+while :; do
+  now=$(date +%s)
+  if (( now > deadline )); then
+    echo "[verify] TIMEOUT after ${TIMEOUT_SEC}s — deploy did not reach 'ready'" >&2
+    exit 20
+  fi
+
+  body=$(curl -fsS "${AUTH_HEADER[@]}" "$DEPLOYS_URL" 2>/dev/null || echo "[]")
+  # Cheap JSON field extraction without jq dependency
+  state=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0].get('state','?') if d else '?')" 2>/dev/null || echo "?")
+  commit=$(echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0].get('commit_ref','') if d else '')" 2>/dev/null || echo "")
+
+  printf "[verify] state=%s commit=%s\n" "$state" "${commit:0:7}"
+
+  case "$state" in
+    ready)
+      if [[ "$commit" == "$EXPECTED_SHA" ]]; then
+        echo "[verify] OK — deployed commit matches HEAD"
+        exit 0
+      fi
+      # It's possible a newer push is still in flight; keep polling briefly
+      echo "[verify] ready but commit mismatch (expected $SHORT_SHA, got ${commit:0:7}) — may be a prior deploy, polling again" >&2
+      ;;
+    error)
+      echo "[verify] Netlify deploy failed — state=error — check build logs in dashboard" >&2
+      exit 21
+      ;;
+    new|uploading|uploaded|preparing|prepared|building|processing|enqueued|"")
+      : # keep polling
+      ;;
+    *)
+      echo "[verify] unknown state: $state — continuing to poll" >&2
+      ;;
+  esac
+
+  sleep "$POLL_INTERVAL_SEC"
+done

--- a/.codex/agents/repo-auditor.toml
+++ b/.codex/agents/repo-auditor.toml
@@ -1,0 +1,64 @@
+name = "repo-auditor"
+description = """
+Use this agent to run a focused, READ-ONLY audit of one of Eias's six PWA repos
+(Geriatrics/Shlav A Mega, InternalMedicine/Pnimit, FamilyMedicine/Mishpacha, Toranot,
+watch-advisor2, ward-helper) and return a prioritized findings report WITHOUT making any
+changes. Delegate to it when the main session needs an audit pass before fixing or deploying,
+so audit output lands in an isolated context instead of polluting the working session. This
+agent finds and reports; it never edits, never deploys, never writes files.
+
+<example>
+Context: Eias is mid-session on a feature and wants the repo's state before shipping.
+user: "audit geriatrics before I deploy"
+assistant: "I'll hand this to the repo-auditor agent for a read-only audit pass and report, then we triage fixes here."
+<commentary>Bounded, read-only audit that benefits from an isolated context window — classic subagent delegation. The main session stays clean for the fix work that follows.</commentary>
+</example>
+
+<example>
+Context: Something feels off after a refactor.
+user: "something's wrong in mishpacha, the question count looks off"
+assistant: "Let me dispatch the repo-auditor to investigate read-only and come back with what it finds."
+<commentary>Investigation that must not make changes yet. The agent reports the cause; Eias decides the fix.</commentary>
+</example>
+
+<example>
+Context: Eias asks to fix and deploy directly.
+user: "fix the header bug in toranot and push"
+assistant: "[uses the audit-fix-deploy command / direct edits — does NOT call repo-auditor]"
+<commentary>This is user-initiated action that includes writing and deploying. repo-auditor is read-only and reports only; use the audit-fix-deploy command for an end-to-end cycle, not this agent.</commentary>
+</example>"""
+developer_instructions = """
+You are a senior code auditor for Eias's six-repo medical PWA stack. You audit ONE repo per run, read-only, and return a prioritized findings report. You never edit, never deploy, never write files. Your job is to find problems precisely and hand a clean triage list back to the main session.
+
+**Stack you audit (detect which one first):**
+- Geriatrics / Shlav A Mega — single-file HTML PWA (one large HTML file, thousands of questions inline)
+- InternalMedicine / Pnimit — VITE app
+- FamilyMedicine / Mishpacha — VITE (Pnimit-clone); question serializer uses `indent=1`
+- Toranot — Codex API proxy + shift management; bundle MUST stay under 150KB
+- watch-advisor2 — separate Supabase project (`oaojkanozbfpofbewtfq`)
+- ward-helper
+
+**Audit process:**
+1. Identify the repo (package.json, layout, single-file-HTML vs VITE). State it up front.
+2. Build/typecheck if applicable. VITE repos: install + build; report any break verbatim. Never "fix" to make it pass — report the failure.
+3. Version + dead-asset sweep: version-string consistency across files; dead/orphaned files; CSS duplication; assets referenced-but-missing or present-but-unreferenced.
+4. Derived-data integrity: hunt the "denominator-invalidates-all-ratios" class — any place a count/denominator is mutated without the dependent ratios/derived fields being regenerated. Confirm regen-gate coverage (`regen_derived.cjs` where present).
+5. Dead-rule hazard: any rule/guard gating on a field that production never sets (always-false → silent false reassurance). Flag every rule whose trigger field is never written in the prod path.
+6. RTL / mixed-script: Hebrew RTL correctness; embedded-English/drug-name token order (fitz/pypdf scramble class) where exam content is involved — flag false-positive garble that should revert to bank originals, never to scrambled source; font stack (Inter before Heebo for mixed script).
+7. Credential hygiene: any hardcoded key/secret/token in source. Flag anything matching live-key shapes (`sk-…`, `*_KEY=`/`_TOKEN=`/`_SECRET=`/`_PASSWORD=`). Never echo a full secret — report file + line + redacted form only.
+8. Bundle size (Toranot specifically): flag if approaching or over 150KB.
+
+**Output format — return exactly this:**
+- **Repo:** <name> | **Build:** pass / fail / n-a
+- **CRITICAL** (data-integrity, security, build-breaking): numbered, each with `file:line` and a one-line "why it bites."
+- **HIGH** (correctness/UX regressions, dead rules): same shape.
+- **LOW** (cosmetic, tech-debt): brief.
+- **CLEAN:** the checks above that passed, one line each — so the main session knows what was actually verified.
+- **Suggested fix order:** the sequence you'd fix in, dependencies first.
+
+**Rules:**
+- Read-only. If you're tempted to edit, that's the signal to write the finding into the report instead.
+- Cite `file:line` for every finding. No vague "somewhere in the code."
+- Never paste a live credential, even one you found. Redact.
+- Don't recommend a fix you haven't located in source. No speculative findings.
+- If the repo is clean on an axis, say so explicitly — silence is not the same as verified."""

--- a/.codex/agents/rules-engine-reviewer.toml
+++ b/.codex/agents/rules-engine-reviewer.toml
@@ -1,0 +1,95 @@
+name = "rules-engine-reviewer"
+description = "Use proactively whenever src/engine/rules.ts or src/engine/drugSafety.ts has been edited, or when the user proposes a new auto-generated task pattern. Enforces the Golden Rule (on-call doctor tasks only), unique group keys, comfort-care suppression correctness, trigger-field narrowness, and regression-test coverage. Read-only — flags violations, does not fix."
+developer_instructions = """
+You are the Toranot rules-engine reviewer. You are paranoid about one thing:\r
+**auto-generating tasks that don't belong to the on-call doctor.**\r
+\r
+## The Golden Rule (from toranot-dev SKILL §4)\r
+\r
+> Auto-generated tasks must ONLY be things on-call doctors should handle.\r
+\r
+Reject anything that is:\r
+- Nursing standing orders (positioning, skin checks, reorientation, repositioning, intake/output)\r
+- Morning team work (routine non-urgent labs, discharge planning, family meetings unless urgent)\r
+- Textbook references exploded into 5+ separate checkboxes instead of a single consolidated line\r
+- Administrative items (social work, PT/OT, speech therapy, dietitian — unless genuinely STAT)\r
+\r
+## What you check, every time\r
+\r
+### 1. Golden Rule violations\r
+For each new or modified rule, read the tasks array and answer for each task:\r
+> "Must the on-call doctor personally do or order this during THIS shift?"\r
+\r
+If "no" / "nice to have" / "morning team" / "nurse" → FLAG as Golden Rule violation.\r
+\r
+### 2. Unique `group` key\r
+```\r
+rg -n "group: \\"" src/engine/rules.ts | awk -F'"' '{print $2}' | sort | uniq -d\r
+```\r
+Any duplicate output = FLAG. Every rule must deduplicate against a unique snake_case group.\r
+\r
+### 3. Trigger field narrowness\r
+- `"all"` should be rare. If used, require a rationale comment.\r
+- `"diagnosis"` is preferred when the trigger is truly diagnostic.\r
+- planNotes/tomorrowNotes are not in the trigger surface — do not assume they are.\r
+\r
+### 4. Comfort-care suppression\r
+If the new rule generates aggressive workup (imaging, invasive labs, specialist consults),\r
+verify that either:\r
+- `COMFORT_CARE_PATTERN` suppression applies at the engine level, OR\r
+- There's an explicit comment justifying why this rule fires even on comfort-care patients.\r
+\r
+DNR/DNI alone does NOT trigger comfort-care suppression. Do not confuse them.\r
+\r
+### 5. Consolidation check\r
+If a rule generates ≥4 similar tasks (e.g. delirium workup labs), prefer a single\r
+consolidated line with pipe separators. Flag laundry-list patterns.\r
+\r
+### 6. Regression tests present\r
+For each new/modified rule, search `src/__tests__/rules.test.ts` for:\r
+- A positive test (`generatedFrom` matches the rule's `source`)\r
+- A negative test (comfort-care suppression OR non-matching patient)\r
+- Updated `expect(RULES.length).toBe(N)` count\r
+\r
+Flag any missing.\r
+\r
+### 7. Drug safety companion\r
+If the rule relates to a drug (renal dose, Beers, interaction), check whether\r
+`src/engine/drugSafety.ts` already surfaces it as an alert. Don't duplicate — alerts\r
+are for passive display; rules.ts is for actionable tasks. If overlap is intentional,\r
+flag the duplication for the author to confirm.\r
+\r
+### 8. Urgency + category plausibility\r
+- `urgency: "stat"` is reserved for genuinely time-critical (minutes–1h). Flag over-use.\r
+- `urgency: "morning"` auto-generated means the doctor should log it and move on —\r
+  rarely needed in an on-call engine. Flag unless clearly justified.\r
+- `category` must be one of: labs, meds, procedure, consult, other.\r
+\r
+## Output format\r
+\r
+For each proposed/modified rule, report:\r
+\r
+```\r
+### Rule: <source> (group: <group>)\r
+  Trigger field: <field>\r
+  Tasks: <count>\r
+\r
+  ✓ Passes: <list of checks>\r
+  ✗ Flags:\r
+    - <specific flag with reference to §N of skill>\r
+    - ...\r
+\r
+  Tests: <present | MISSING: positive | MISSING: negative | MISSING: RULES.length bump>\r
+```\r
+\r
+End with an overall verdict: `APPROVE` / `REQUEST_CHANGES` / `REJECT`.\r
+\r
+- APPROVE: zero flags, tests present.\r
+- REQUEST_CHANGES: 1+ flag, but fixable.\r
+- REJECT: Golden Rule violation or duplicate group.\r
+\r
+## Do not\r
+\r
+- Do not rewrite rules yourself. You're a reviewer.\r
+- Do not soften a Golden Rule rejection with "but if…" hedging.\r
+- Do not accept "the tests will fail anyway so CI will catch it" as coverage."""

--- a/.codex/agents/toranot-auditor.toml
+++ b/.codex/agents/toranot-auditor.toml
@@ -1,0 +1,111 @@
+name = "toranot-auditor"
+description = "Use proactively after any substantive change to the Toranot codebase, and always as step 7 of toranot-ship. Sweeps for regressions the CI doesn't always catch: dismissed-task leaks, RULES.length drift, banned-pattern leaks, console.log leaks, test count drift, bundle size, import graph breakage. Read-only — reports findings, does not auto-fix."
+developer_instructions = """
+You are the Toranot regression auditor. You run AFTER code changes, not as part of the edit.\r
+Your job is to spot the specific bug classes that cost the team time between commits.\r
+\r
+## Rules of engagement\r
+\r
+- **Read-only.** Never edit files, never run the ship pipeline, never commit.\r
+- **Be specific.** Every finding must include: file path, line number (or grep hit),\r
+  the exact snippet, and which toranot-dev SKILL.md invariant it violates.\r
+- **Be terse.** Output is a punch list. No filler, no congratulations.\r
+- **No generic advice.** "Consider adding more tests" is forbidden. Either a specific\r
+  test is missing (name it) or nothing.\r
+\r
+## Checklist (run every sweep, in order)\r
+\r
+### 1. Dismissed-task leak\r
+The skill says: `done: true, dismissed: true` tasks must be filtered from ALL aggregations\r
+(totals, summaries, shift reports). Grep aggregation paths for missing filters.\r
+\r
+```\r
+rg -n "\\.tasks\\.(filter|map|reduce|length)|generatedTasks\\.(filter|length)" src/ --glob '!*.test.*'\r
+```\r
+For each aggregation, check whether the chain filters out `dismissed`. Flag any that doesn't.\r
+\r
+### 2. RULES.length drift\r
+```\r
+rg -c "^\\s*\\{" src/engine/rules.ts | grep -v ':0$'   # rough count\r
+rg -n "expect\\(RULES\\.length\\)\\.toBe\\(" src/__tests__/rules.test.ts\r
+```\r
+If the test assertion number doesn't match the actual array length → flag.\r
+\r
+### 3. Banned pattern leaks (outside tests)\r
+```\r
+rg -n "\\btransition-all\\b" src/ --glob '!*.test.*'\r
+rg -n "\\bconfirm\\s*\\(" src/ --glob '!*.test.*' --glob '!netlify/functions/**'\r
+rg -n "animate-card-in" src/ --glob '*.css' -A 3 -B 1 | rg "will-change"\r
+```\r
+Any hit = finding.\r
+\r
+### 4. Mid-file imports\r
+```\r
+for f in $(fd '\\.(ts|tsx)$' src/); do\r
+  awk '/^import .* from / { if (seen) { print FILENAME ":" NR ": " $0; exit } } !/^(import|\\/\\/|\\/\\*|\\*|$| \\*)/ { seen=1 }' "$f"\r
+done\r
+```\r
+Any output = finding.\r
+\r
+### 5. Console.log leaks in production code\r
+```\r
+rg -n "console\\.(log|debug)" src/ --glob '!*.test.*' --glob '!**/DebugConsole.tsx'\r
+```\r
+`console.warn` and `console.error` are fine (they feed errorReporter).\r
+\r
+### 6. Test count drift\r
+```\r
+npx vitest list --reporter=json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print('tests:', sum(len(f.get('tasks',[])) for f in d.get('files',[])), 'files:', len(d.get('files',[])))"\r
+```\r
+Compare to README.md + AGENTS.md claim (1706 / 52 as of skill last update).\r
+Flag the mismatch — don't auto-fix, just report both numbers.\r
+\r
+### 7. Bundle size\r
+```\r
+if [[ -d dist ]]; then\r
+  find dist/assets -name 'index-*.js' -printf '%s %p\\n' | sort -nr | head -1\r
+fi\r
+```\r
+Flag if main chunk > 153600 bytes (150KB budget).\r
+\r
+### 8. Import graph breakage (quick heuristic)\r
+```\r
+rg -n "^import .* from ['\\"]\\./" src/ | awk -F: '{print $1 "|" $3}' | while IFS='|' read -r file line; do\r
+  # resolve the ./ path and check it exists — too expensive to script here,\r
+  # so just flag files that have edit timestamps in the last 24h and rerun tsc --noEmit\r
+  :\r
+done\r
+```\r
+Preferred: just run `npx tsc --noEmit` once and surface any errors verbatim.\r
+\r
+### 9. Room-format 5-file symmetry\r
+If `ROOM_PATTERN` changed in `src/parser/parsePatientList.ts`, verify the other 4 input\r
+paths (AddAdmissionModal, Scanner, VoiceInput, QuickCaptureSheet) plus the test suite\r
+have consistent handling. Grep each file for the known formats: `ניטור`, `א-`, `49/2`.\r
+\r
+### 10. Acuity score + ACB + falls consistency\r
+Per skill §5b, acuity pulls from ACB + falls. If either `calculateACB` or `calculateFallsRisk`\r
+changed, verify `src/engine/acuity.ts` still references them with expected weights.\r
+\r
+## Output format\r
+\r
+```\r
+## Toranot Auditor Report — <ISO date>\r
+\r
+### Blocking (must fix before next ship)\r
+1. <finding with file:line + invariant violated>\r
+2. ...\r
+\r
+### Warnings (fix on next ship)\r
+1. ...\r
+\r
+### Clean\r
+- Dismissed-task filters: OK\r
+- RULES.length: OK (N = <n>)\r
+- Bundle: OK (<size> / 150KB)\r
+- Test count: OK (<n> tests / <m> files)\r
+```\r
+\r
+If no findings at all, output exactly: `Toranot Auditor — clean.`\r
+\r
+Never output "looks good" or congratulatory language. You're an auditor, not a cheerleader."""

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'if echo \"$CLAUDE_TOOL_INPUT\" | grep -q \"push origin main\" 2>/dev/null; then echo \"[skill-hook] Deploy pushed — run /toranot-update-skill to sync skill file\"; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,6 +1,26 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .codex/hooks/ban-patterns.cjs"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .codex/hooks/room-format-drift.cjs"
+          }
+        ]
+      },
       {
         "matcher": "Bash",
         "hooks": [

--- a/.codex/hooks/ban-patterns.cjs
+++ b/.codex/hooks/ban-patterns.cjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// PreToolUse hook for Toranot — blocks the exact foot-guns the skill file calls out.
+//
+// Triggers on Edit / Write / MultiEdit. Reads tool input on stdin.
+// Exit 0 = allow; exit 2 = block (Claude sees the stderr output and cannot proceed).
+//
+// Banned patterns (from toranot-dev SKILL.md):
+//   1. `transition-all`  — banned CSS utility (causes layout jank)
+//   2. `will-change`-on-`animate-card-in` rules (layer explosion)
+//   3. `confirm(`        — silently fails in Android PWA standalone
+//   4. mid-file `import` statements (crashes Vite)
+//
+// Scoped to src/**/*.{ts,tsx,css} and public/**/*.css by default.
+// Skips test files (intentional test fixtures may reference the strings).
+
+const fs = require("fs");
+
+let input;
+try {
+  input = JSON.parse(fs.readFileSync(0, "utf8"));
+} catch {
+  process.exit(0); // no input, nothing to check
+}
+
+const { tool_name, tool_input } = input || {};
+if (!tool_name || !tool_input) process.exit(0);
+if (!["Edit", "Write", "MultiEdit"].includes(tool_name)) process.exit(0);
+
+const path = tool_input.file_path || "";
+if (!path) process.exit(0);
+
+// Only scope to source files inside Toranot repo. Skip tests + node_modules + dist.
+// Match both absolute paths (/repo/src/...) and relative (src/...)
+const inScope = /(^|\/)(src|public)\//.test(path) &&
+                /\.(ts|tsx|js|jsx|css|html)$/.test(path) &&
+                !/__tests__|\.test\.|\.spec\.|node_modules|dist/.test(path);
+if (!inScope) process.exit(0);
+
+// Aggregate the new content across Edit/Write/MultiEdit shapes
+const chunks = [];
+if (tool_input.content) chunks.push(tool_input.content);
+if (tool_input.new_string) chunks.push(tool_input.new_string);
+if (Array.isArray(tool_input.edits)) {
+  for (const e of tool_input.edits) if (e && e.new_string) chunks.push(e.new_string);
+}
+const text = chunks.join("\n");
+if (!text) process.exit(0);
+
+const findings = [];
+
+// 1. `transition-all` — always banned in Tailwind class context
+if (/\btransition-all\b/.test(text)) {
+  findings.push("`transition-all` is banned — use specific transitions like `transition-[width]`, `transition-colors`. See toranot-dev SKILL §3 CSS/Performance.");
+}
+
+// 2. will-change on animate-card-in — banned combo
+if (/animate-card-in[^\n]*will-change|will-change[^\n]*animate-card-in/.test(text)) {
+  findings.push("`will-change` on `animate-card-in` is banned (causes layer explosion). See toranot-dev SKILL §3.");
+}
+
+// 3. confirm() in PWA components — silently fails on Android standalone
+if (path.match(/\.(tsx|jsx|ts|js)$/) && /\bconfirm\s*\(/.test(text)) {
+  // Allow confirm in netlify/functions (server) and obvious lint/test utility
+  if (!/netlify\/functions/.test(path)) {
+    findings.push("`confirm()` is banned in PWA code (silently fails on Android standalone). Use a React state modal instead. See toranot-dev SKILL §9.");
+  }
+}
+
+// 4. Mid-file import statement (Vite crashes on these)
+if (path.match(/\.(tsx|jsx|ts|js)$/)) {
+  const lines = text.split("\n");
+  let seenNonImport = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line || line.startsWith("//") || line.startsWith("/*") || line.startsWith("*") || line.startsWith("'use ")) continue;
+    if (line.startsWith("import ") && line.includes("from ")) {
+      if (seenNonImport) {
+        findings.push(`mid-file \`import\` at line ~${i+1} — move all imports to the top of the file (Vite will crash otherwise). See toranot-dev SKILL §9.`);
+        break;
+      }
+    } else {
+      seenNonImport = true;
+    }
+  }
+}
+
+if (findings.length === 0) process.exit(0);
+
+console.error("\n[ban-patterns] Edit blocked — fix the following before writing to " + path + ":\n");
+for (const f of findings) console.error("  • " + f);
+console.error("");
+process.exit(2);

--- a/.codex/hooks/room-format-drift.cjs
+++ b/.codex/hooks/room-format-drift.cjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// PostToolUse hook for Toranot — warns when a room-format file was edited
+// without touching the others. Room format lives in 5 files + 1 test suite;
+// missing any of them causes silent parser drift.
+//
+// Emits advisory output on stdout (does NOT block). Claude will see the
+// warning in the next turn's tool_result and can surface it to the user.
+//
+// Tracked files (from toranot-dev SKILL §3 + §10):
+//   src/parser/parsePatientList.ts          (ROOM_PATTERN + letter-prefix handling)
+//   src/components/AddAdmissionModal.tsx    (parseFreestyle, validation)
+//   src/components/Scanner.tsx              (OCR prompt normalization)
+//   src/components/VoiceInput.tsx           (ROOM_PATTERN for speech)
+//   src/components/QuickCaptureSheet.tsx    (extractRoom, normRoom)
+//   src/__tests__/roomFormat.simulation.test.ts  (104-scenario suite)
+
+const fs = require("fs");
+
+let input;
+try { input = JSON.parse(fs.readFileSync(0, "utf8")); }
+catch { process.exit(0); }
+
+const { tool_name, tool_input } = input || {};
+if (!["Edit", "Write", "MultiEdit"].includes(tool_name)) process.exit(0);
+const path = (tool_input && tool_input.file_path) || "";
+if (!path) process.exit(0);
+
+const TRACKED = [
+  { key: "parser",    match: /parsePatientList\.ts$/ },
+  { key: "admission", match: /AddAdmissionModal\.tsx$/ },
+  { key: "scanner",   match: /Scanner\.tsx$/ },
+  { key: "voice",     match: /VoiceInput\.tsx$/ },
+  { key: "capture",   match: /QuickCaptureSheet\.tsx$/ },
+  { key: "tests",     match: /roomFormat\.simulation\.test\.ts$/ },
+];
+
+const hit = TRACKED.find(t => t.match.test(path));
+if (!hit) process.exit(0);
+
+// Check whether the edit actually touched the ROOM_PATTERN or room-parsing logic.
+// Heuristic: look at the new content for room-format signals.
+const newText = [
+  tool_input.content,
+  tool_input.new_string,
+  ...(tool_input.edits || []).map(e => e?.new_string || ""),
+].filter(Boolean).join("\n");
+
+const roomSignals = [
+  /ROOM_PATTERN/,
+  /parseFreestyle/,
+  /extractRoom/,
+  /normRoom/,
+  /\bניטור\b/,
+  /ROOM|[Rr]oom/,
+  /א-\d+|ב-\d+|ג-\d+|\d+-א/,
+];
+const touchedRoomLogic = roomSignals.some(r => r.test(newText));
+if (!touchedRoomLogic) process.exit(0);
+
+const others = TRACKED.filter(t => t.key !== hit.key).map(t => {
+  const display = {
+    parser:    "src/parser/parsePatientList.ts",
+    admission: "src/components/AddAdmissionModal.tsx",
+    scanner:   "src/components/Scanner.tsx",
+    voice:     "src/components/VoiceInput.tsx",
+    capture:   "src/components/QuickCaptureSheet.tsx",
+    tests:     "src/__tests__/roomFormat.simulation.test.ts",
+  }[t.key];
+  return display;
+});
+
+// Non-blocking advisory output (PostToolUse)
+console.log("\n[room-format-drift] Heads up — you edited a room-format file (" + path + ").");
+console.log("[room-format-drift] Room format logic must stay in sync across all 6 touchpoints.");
+console.log("[room-format-drift] Verify you also updated (or intentionally skipped) each of these:");
+for (const o of others) console.log("  • " + o);
+console.log("[room-format-drift] Reference: toranot-dev SKILL §3 'Room Format' + §10 'Update room format'.\n");
+process.exit(0);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,294 @@
+# AGENTS.md — Toranot (תורנות)
+
+## Operating model — single lane (from 2026-05-19)
+
+Development on this repo is done by Codex directly — design,
+implementation, testing, and shipping all in one session. This **supersedes**
+every "two-lane", "web-lane", or "terminal-lane" instruction in older docs and
+skills (audit-fix-deploy and the per-repo skills included): there is no second
+Codex lane, and no `Codex/web-` vs `Codex/term-` branch split.
+
+Workflow: branch `Codex/<slug>` -> PR -> CI green + Codex review -> Codex
+self-merges -> post-merge `verify-deploy`. Codex is the independent automated
+reviewer. Codex green + CI green is sufficient self-merge authority.
+**"Codex green" is defined as:** review state ∈ {`APPROVED`, `COMMENTED`} AND no unresolved P0 or P1 inline comments at the moment of merge. P2 inline comments may self-merge with an in-thread reply explaining the decision. Auto-merge (`gh pr merge --auto`) is **disabled** — every self-merge requires explicitly reading the latest Codex review surface and CI status before merging. If Codex has not reviewed and the PR is substantive, wait or ping; do not deadline-out a missing reviewer on non-trivial changes.
+
+ Eias sign-off is required only for: (a) PRs touching patient-data paths (ward-helper PHI crypto, IDB roster schema, rounds-data persistence — enumerated in ward-helper codeowners, queued as follow-up PR), and (b) per-PR gate docs that explicitly carry a "NO self-merge" clause (audit-8 R1.5 / R1.6 and subsequent R1.x gates). Codex never self-certifies its own audit — independence comes from cross-model review (Codex), not from human-vs-AI gates. All release,
+version-trinity, and verification rules in the repo's skill still apply
+unchanged.
+
+
+<!-- working-rules-v1:start -->
+## Working Rules (user-mandated, non-negotiable)
+
+These four rules are the floor. They override any conflicting guidance later in this file. If a rule conflicts with what you're about to do, stop and surface it before proceeding.
+
+1. **Don't assume. Don't hide confusion. Surface tradeoffs.**
+2. **Minimum code that solves the problem. Nothing speculative.**
+3. **Touch only what you must. Clean up only your own mess.**
+4. **Define success criteria. Loop until verified.**
+<!-- working-rules-v1:end -->
+
+Hospital ward shift management PWA for on-call doctors at Shaare Zedek Medical Center (geriatric/internal medicine). Hebrew-first, RTL design.
+
+Live: https://toranot.netlify.app
+
+## Quick Commands
+
+```bash
+npm run dev          # Dev server at http://localhost:5173/Toranot/
+npm test             # Run all tests (vitest, ~2,150 tests across 75 files)
+npm run build        # TypeScript check + Vite build → dist/
+npm run typecheck    # tsc --noEmit (strict mode)
+```
+
+Requires Node.js >= 22.0.0.
+
+## Tech Stack
+
+- **React 19.2** + **TypeScript 5.4** (strict mode)
+- **Zustand 5** — state management (source of truth, localStorage-backed)
+- **Tailwind CSS 4.1** — styling with dark mode
+- **Vite 7.3** — build tool with manual chunk splitting + SW version stamping
+- **Vitest 4** — testing framework (jsdom environment)
+- **Supabase 2.49** — optional cloud sync + OTP auth
+- **Netlify Functions** — serverless API proxies (Codex, Gemini, OCR, GitHub PAT)
+- **Dexie 4 (IndexedDB)** — photo blob storage
+- **DOMPurify** — AI-generated HTML sanitization
+
+## Project Structure
+
+```
+src/
+├── App.tsx                    # Main app component
+├── main.tsx                   # React root + service worker registration
+├── store/patientsStore.ts     # Zustand store (source of truth)
+├── context/
+│   ├── PatientsContext.tsx     # React Context wrapper (backward compat)
+│   └── reducer.ts             # State reducer + Action types (extracted to break circular imports)
+├── types/patient.ts           # PatientEntry, Task, LabEntry, PatientSection, etc.
+├── engine/                    # Deterministic business logic (13 files)
+│   ├── rules.ts               # 57 rule groups for task generation
+│   ├── drugSafety.ts          # Beers Criteria 2023, drug interactions, renal dosing
+│   ├── labDelta.ts            # KDIGO AKI / Hb delta alerting
+│   ├── acuity.ts              # Patient acuity scoring
+│   ├── admissionProcessor.ts  # Intake → structured admission pipeline
+│   ├── anticholinergicBurden.ts # ACB scoring
+│   ├── fallsRisk.ts           # Falls risk assessment
+│   ├── hints.ts               # Clinical hints engine
+│   ├── ivProtocolMatch.ts     # IV protocol matching
+│   ├── mergeScan.ts           # OCR/parser deduplication
+│   ├── shiftContinuity.ts     # Cross-shift task continuity
+│   ├── shiftIntegrity.ts      # Shift data integrity checks
+│   └── smartOCR.ts            # Diff reporting
+├── clinical/
+│   └── clinicalThresholds.ts  # Canonical lab thresholds (single source of truth)
+├── parser/
+│   ├── parsePatientList.ts    # WhatsApp/nurse-call text → PatientEntry[]
+│   └── chameleonExport.ts     # Rounds-note exporter for Chameleon EMR paste
+├── data/
+│   ├── dosing.ts              # Renal dosing table (19 antibiotics, CrCl buckets)
+│   └── drugHazards.json       # Drug hazard databases
+├── components/                # 46 React components
+│   ├── PatientCard.tsx        # Main patient display (~1500 lines)
+│   ├── PatientList.tsx        # Patient list with filtering
+│   ├── HandoffSheet.tsx       # Shift handoff document (5 tabs)
+│   ├── AIClinicalReasoning.tsx # Codex-powered clinical reasoning
+│   ├── Scanner.tsx            # Camera OCR via Anthropic Vision API
+│   ├── AddAdmissionModal.tsx  # Admission workflow
+│   ├── OnCallProtocols.tsx    # IV/clinical protocol reference
+│   └── ...                    # 38+ more components (many lazy-loaded)
+└── __tests__/                 # 75 test files, ~2,150 tests
+
+netlify/functions/             # Serverless API proxies + ops helpers
+├── Codex.ts, gemini.ts, ocr-proxy.ts, github-pat.ts  # AI/auth proxies
+├── feedback-notify.ts                                  # feedback triage webhook
+├── self-audit.js, skill-snapshot.js, toranot-keepalive.js  # ops/scheduled
+└── _utils.ts                  # Shared auth, rate limiting, validation
+
+public/
+├── sw.js, manifest.json, iv-protocols.json, szmc-iv-protocols.json
+```
+
+**Codebase size**: ~168 TypeScript/TSX files (~92 source + 75 test + 1 index).
+
+## Architecture
+
+### State Management
+- **Zustand store** (`store/patientsStore.ts`) is the single source of truth
+- **React Context** wraps Zustand for backward compatibility
+- **Reducer** extracted separately to break circular imports
+- State persists to **localStorage**; optional **Supabase** cloud sync
+
+### Engine (Business Logic)
+All clinical logic in `src/engine/` — deterministic, pure functions, heavily tested.
+
+### Cloud Sync
+- Debounced push, echo suppression, conflict detection + merge
+- Per-patient revision tracking, retry with exponential backoff + jitter
+
+### Serverless Functions (Netlify)
+- Proxy Codex/Gemini APIs (keys server-side), JWT auth, rate limiting
+
+## Testing
+
+**~2,150 tests across 75 files** — run `npm test` to see current count.
+
+Always run `npm test` before every push. ALL tests must pass.
+
+**Auto-expand rule:** Every feature or bug fix MUST include new or updated tests.
+
+### Test coverage by area
+
+| Area | Tests | Status |
+|------|-------|--------|
+| Engine (rules, drugSafety, labDelta) | ~530 | Strong |
+| Clinical utils (renal, acuity, falls, hints) | ~190 | Strong |
+| Parser (patient list, freestyle, normalize) | ~195 | Strong |
+| Reducer + store | ~168 | Strong |
+| On-call scheduling | ~157 | Strong |
+| Cloud sync + merge | ~84 | Good |
+| IV protocols + dosing | ~74 | Good |
+| Lab processing | ~73 | Good |
+| Serverless functions | ~59 | Good |
+| Shift management | ~46 | Good |
+| Storage + export | ~43 | Good |
+| Patient card component | ~35 | Moderate |
+| Handoff sheet | ~34 | Good |
+
+**Gaps — areas not tested:**
+- 45 of 46 React components (only PatientCard has tests)
+- UI interactions, navigation, modal workflows
+- Service worker (offline caching, background sync)
+- Supabase real-time subscriptions (tested via mocks only)
+
+## Environment Variables
+
+```bash
+# Client-side (Vite)
+VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_BASE_PATH=/Toranot/
+# Server-side (Netlify Functions)
+ANTHROPIC_API_KEY, GEMINI_API_KEY, CLAUDE_MODEL, GEMINI_MODEL
+UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN, API_SECRET
+```
+
+## CI/CD
+
+**GitHub Actions**: test → build → deploy (GitHub Pages). Node 22.
+**Netlify**: Auto-deploys from main; API routes, CSP headers, scheduled functions.
+
+## Code Conventions
+
+- **TypeScript strict mode** — no `any` unless necessary
+- **UI text**: Hebrew (RTL)
+- **Tailwind CSS**; dark mode via class toggling
+- **React.lazy** for heavy modals; `useSimpleConfirm` not `window.confirm`
+- Engine rules must respect `goalsOfCare === 'comfort'`
+- Lab thresholds from `clinical/clinicalThresholds.ts` (single source)
+- All engine functions must be pure — no side effects
+
+## Key Files
+
+| File | Why It Matters |
+|------|---------------|
+| `src/store/patientsStore.ts` | App state source of truth |
+| `src/context/reducer.ts` | All actions + normalizers |
+| `src/engine/rules.ts` | 57 clinical rule groups |
+| `src/engine/drugSafety.ts` | Beers, interactions, renal |
+| `src/clinical/clinicalThresholds.ts` | Canonical lab thresholds |
+| `src/types/patient.ts` | Core type definitions |
+| `src/parser/parsePatientList.ts` | Text → PatientEntry[] |
+| `src/components/PatientCard.tsx` | Main UI (~1,500 lines) |
+| `netlify/functions/_utils.ts` | Shared auth + rate limiting |
+
+## Common Tasks
+
+### Adding a new clinical rule
+1. Add rule group in `src/engine/rules.ts`
+2. Respect comfort care: check `goalsOfCare`
+3. Use thresholds from `clinicalThresholds.ts`
+4. Add tests in `src/__tests__/rules.test.ts`
+
+### Adding a new patient field
+1. Add optional field to `PatientEntry` in `src/types/patient.ts`
+2. Update `normalizePatient` in `src/context/reducer.ts`
+3. Field must be optional (backward compat)
+
+---
+
+## Codebase Metrics
+
+| Metric | Value |
+|--------|-------|
+| Source files (TS/TSX) | ~92 |
+| Test files | 75 |
+| Total tests | ~2,150 |
+| Components | 46 |
+| Engine modules | 13 |
+| Clinical rule groups | 57 |
+| Renal dosing drugs | 19 |
+| Netlify functions | 8 (+1 shared utils) |
+| Patient sections | 5 (SIDE_A–C, REHAB, MONITOR) |
+
+---
+
+## Test Coverage Recommendations
+
+### Recommended Additions (Priority Order)
+
+1. **Component testing expansion** — Only PatientCard tested (1/46). Priority:
+   - `AddAdmissionModal.tsx` — form validation, templates, geriatric baselines
+   - `HandoffSheet.tsx` — all 5 tab renders, export formatting
+   - `Scanner.tsx` — OCR trigger, confidence, error states
+   - `MedicationInput.tsx` — structured entry, ACB preview, validation
+   - `PatientList.tsx` — filtering, sorting, section grouping
+2. **Service worker tests** — offline caching, background sync, auto-update
+3. **Supabase real-time subscription tests** — integration-style lifecycle tests
+4. **Error boundary coverage** — `InlineErrorBoundary` fallback rendering
+5. **Voice input tests** — `VoiceInput.tsx` speech-to-text
+6. **Photo persistence tests** — Dexie IndexedDB blob storage
+7. **Rate limiting boundary tests** — Upstash Redis at 29th vs 31st request
+8. **Room format edge cases** — SZMC-specific numbering
+9. **Shift handoff cross-patient tests** — 10+ patients, mixed sections/acuity
+10. **AI clinical reasoning tests** — mock Codex responses, DOMPurify sanitization
+
+### Long-Term Goal
+Reach **2,500+ tests** with at least 10 component test files.
+
+---
+
+## TODO / Improvement Roadmap
+
+### High Priority
+- [ ] **Component test coverage** — top 5 critical components
+- [ ] **Service worker test file** — caching, version sync, background sync
+- [ ] **Coverage thresholds** — target Lines >=50%, Branches >=40%
+- [ ] **PatientCard refactoring** — continue extracting sub-components
+
+### Medium Priority
+- [ ] **Structured medication database** — expand drugHazards.json
+- [ ] **Lab trend visualization** — sparkline/mini-charts
+- [ ] **Multi-ward support** — extend PatientSection
+- [ ] **Admission template expansion** — beyond current 8
+- [ ] **Push notification reliability** — test and improve delivery
+
+### Low Priority
+- [ ] **Performance optimization** — PatientCard re-render profiling
+- [ ] **Offline resilience testing** — offline → online transitions
+- [ ] **i18n preparation** — extract Hebrew strings for future locales
+- [ ] **Accessibility audit** — WCAG compliance
+- [ ] **Bundle size monitoring** — track chunk sizes
+
+### Clinical Content Roadmap
+- [ ] **Rule expansion** — delirium screening (4AT/CAM), pressure injury (Braden), nutrition (MNA)
+- [ ] **Drug database expansion** — more Beers drugs, STOPP/START v3
+- [ ] **Protocol library** — more SZMC-specific protocols
+- [ ] **Clinical calculators** — GDS-15, Norton, Morse Fall, CFS
+
+---
+
+## Branch Policy
+
+- `main` — production, auto-deployed to Netlify + GitHub Pages
+- Feature branches: `Codex/<description>-<id>` convention
+- CI must pass before merging


### PR DESCRIPTION
Housekeeping from the 2026-06-09 workspace audit: these files sat untracked since 2026-06-06. Committing per the Geriatrics #351 precedent (AGENTS.md + .agents/skills are repo-tracked there).

Contents: AGENTS.md (Codex single-lane operating doc), .agents/skills/ (4 skills incl. toranot-ship), .codex/ (3 agent TOMLs + 2 hooks + hooks.json). Secret-scanned clean — the one grep hit is the `ghp_xxx` placeholder in push-with-pat.sh's usage comment; the script takes the PAT from env and scrubs the remote URL on every exit path.

One flag for review: `toranot-ship/scripts/push-with-pat.sh` ships to `main` directly, which is in tension with the workspace always-PR rule; committed as-is since AGENTS.md in the same tree mandates branch→PR. Consider retiring or rewriting that script later.

No app code touched; no version bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)